### PR TITLE
Separate loggers depending on part of program.

### DIFF
--- a/statbot/__main__.py
+++ b/statbot/__main__.py
@@ -61,10 +61,10 @@ if __name__ == '__main__':
         return logger
 
     discord_logger = get_logger('discord', logging.INFO)
-    main_logger = get_logger('main')
-    event_logger = get_logger('event')
-    crawler_logger = get_logger('crawler')
-    sql_logger = get_logger('sql')
+    main_logger = get_logger('statbot')
+    event_logger = get_logger('statbot.event')
+    crawler_logger = get_logger('statbot.crawler')
+    sql_logger = get_logger('statbot.sql')
     del get_logger
 
     # Enable specified logs

--- a/statbot/__main__.py
+++ b/statbot/__main__.py
@@ -37,9 +37,6 @@ if __name__ == '__main__':
     argparser.add_argument('-q', '--quiet', '--no-stdout',
             dest='stdout', action='store_false',
             help="Don't output to standard out.")
-    argparser.add_argument('-l', '--include-log',
-            dest='loglist', type=str, nargs='*',
-            help="Specify which logs you want outputted.")
     argparser.add_argument('-d', '--debug',
             dest='debug', action='store_true',
             help="Set logging level to debug.")
@@ -67,34 +64,17 @@ if __name__ == '__main__':
     sql_logger = get_logger('statbot.sql')
     del get_logger
 
-    # Enable specified logs
-    if args.loglist is None:
-        loggers = [main_logger, event_logger, crawler_logger, sql_logger]
-        if args.debug:
-            loggers.append(discord_logger)
-    else:
-        logger_names = {
-            'discord': discord_logger,
-            'main': main_logger,
-            'event': event_logger,
-            'crawler': crawler_logger,
-            'sql': sql_logger,
-        }
-        try:
-            loggers = [logger_names[logname] for logname in args.loglist]
-        except KeyError:
-            print(f"No such logger: {logname}")
-            exit(1)
-
-    # Map to outputs
-    for logger in loggers:
-        logger.addHandler(log_hndl)
+    # Map logging to outputs
+    main_logger.addHandler(log_hndl)
+    if args.debug:
+        discord_logger.addHandler(log_hndl)
 
     if args.stdout:
         log_out_hndl = logging.StreamHandler(sys.stdout)
         log_out_hndl.setFormatter(log_fmtr)
-        for logger in loggers:
-            logger.addHandler(log_out_hndl)
+        main_logger.addHandler(log_out_hndl)
+        if args.debug:
+            discord_logger.addHandler(log_out_hndl)
 
     # Get and verify configuration
     config, valid = load_config(args.config_file, main_logger)

--- a/statbot/__main__.py
+++ b/statbot/__main__.py
@@ -69,14 +69,15 @@ if __name__ == '__main__':
 
     # Enable specified logs
     if args.loglist is None:
-        loggers = [main_logger, event_logger, sql_logger]
+        loggers = [main_logger, event_logger, crawler_logger, sql_logger]
         if args.debug:
             loggers.append(discord_logger)
     else:
         logger_names = {
-            'main': main_logger,
             'discord': discord_logger,
+            'main': main_logger,
             'event': event_logger,
+            'crawler': crawler_logger,
             'sql': sql_logger,
         }
         try:

--- a/statbot/__main__.py
+++ b/statbot/__main__.py
@@ -58,6 +58,7 @@ if __name__ == '__main__':
     def get_logger(name, level=log_level):
         logger = logging.getLogger(name)
         logger.setLevel(level=level)
+        return logger
 
     discord_logger = get_logger('discord', logging.INFO)
     main_logger = get_logger('main')

--- a/statbot/__main__.py
+++ b/statbot/__main__.py
@@ -55,17 +55,16 @@ if __name__ == '__main__':
     log_level = (logging.DEBUG if args.debug else logging.INFO)
 
     # Create instances
-    discord_logger = logging.getLogger('discord')
-    discord_logger.setLevel(level=logging.INFO)
+    def get_logger(name, level=log_level):
+        logger = logging.getLogger(name)
+        logger.setLevel(level=level)
 
-    main_logger = logging.getLogger('main')
-    main_logger.setLevel(level=log_level)
-
-    event_logger = logging.getLogger('event')
-    event_logger.setLevel(level=log_level)
-
-    sql_logger = logging.getLogger('sql')
-    sql_logger.setLevel(level=log_level)
+    discord_logger = get_logger('discord', logging.INFO)
+    main_logger = get_logger('main')
+    event_logger = get_logger('event')
+    crawler_logger = get_logger('crawler')
+    sql_logger = get_logger('sql')
+    del get_logger
 
     # Enable specified logs
     if args.loglist is None:

--- a/statbot/__main__.py
+++ b/statbot/__main__.py
@@ -103,7 +103,8 @@ if __name__ == '__main__':
         exit(1)
 
     # Open and run event client
-    main_logger.info("Starting bot...")
+    main_logger.info("Setting up bot")
     client = EventIngestionClient(config, event_logger, sql_logger=sql_logger)
+    main_logger.info("Starting bot, waiting for discord.py...")
     client.run()
 

--- a/statbot/__main__.py
+++ b/statbot/__main__.py
@@ -86,12 +86,14 @@ if __name__ == '__main__':
             exit(1)
 
     # Map to outputs
-    map(lambda x: x.addHandler(log_hndl), loggers)
+    for logger in loggers:
+        logger.addHandler(log_hndl)
 
     if args.stdout:
         log_out_hndl = logging.StreamHandler(sys.stdout)
         log_out_hndl.setFormatter(log_fmtr)
-        map(lambda x: x.addHandler(log_out_hndl), loggers)
+        for logger in loggers:
+            logger.addHandler(log_out_hndl)
 
     # Get and verify configuration
     config, valid = load_config(args.config_file, main_logger)

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -130,6 +130,7 @@ class DiscordSqlHandler:
 
         # Create tables
         self.meta.create_all(self.db)
+        self.logger.info("Created all tables.")
 
     # Value builders
     @staticmethod


### PR DESCRIPTION
This PR does the following:

* Adds a command line option `-l` which allows you to manually specify which logs you want.
* Removes some of the logger boilerplate
* Makes the `discord` logger only be activated in debug mode
* Only prints non-`discord` logs in debug mode