### PR TITLE
Group all event modifications into transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Configuration
-/config.json
+/config*.json
 /docker-compose.yaml
 
 # Artifacts

--- a/statbot/client.py
+++ b/statbot/client.py
@@ -133,7 +133,7 @@ class EventIngestionClient(discord.Client):
         self._log(message, 'created')
 
         with self.sql.transaction() as trans:
-            trans.add_message(message)
+            self.sql.add_message(trans, message)
 
     async def on_message_edit(self, before, after):
         self.logger.debug(f"Message id {after.id} edited")
@@ -143,7 +143,7 @@ class EventIngestionClient(discord.Client):
         self._log(after, 'edited')
 
         with self.sql.transaction() as trans:
-            trans.edit_message(before, after)
+            self.sql.edit_message(trans, before, after)
 
     async def on_message_delete(self, message):
         self.logger.debug(f"Message id {message.id} deleted")
@@ -153,7 +153,7 @@ class EventIngestionClient(discord.Client):
         self._log(message, 'deleted')
 
         with self.sql.transaction() as trans:
-            trans.remove_message(message)
+            self.sql.remove_message(trans, message)
 
     async def on_typing(self, channel, user, when):
         self.logger.debug(f"User id {user.id} is typing")
@@ -163,7 +163,7 @@ class EventIngestionClient(discord.Client):
         self._log_typing(channel, user)
 
         with self.sql.transaction() as trans:
-            trans.typing(channel, user, when)
+            self.sql.typing(trans, channel, user, when)
 
     async def on_reaction_add(self, reaction, user):
         self.logger.debug(f"Reaction {reaction.emoji} added")
@@ -174,7 +174,7 @@ class EventIngestionClient(discord.Client):
 
         self.logger.warn("TODO: handling for on_reaction_add")
         #with self.sql.transaction() as trans:
-            #trans.add_reaction(reaction, user)
+            #self.sql.add_reaction(trans, reaction, user)
 
     async def on_reaction_remove(self, reaction, user):
         self.logger.debug(f"Reaction {reaction.emoji} removed")
@@ -185,7 +185,7 @@ class EventIngestionClient(discord.Client):
 
         self.logger.warn("TODO: handling for on_reaction_remove")
         #with self.sql.transaction() as trans:
-            #trans.remove_reaction(reaction, user)
+            #self.sql.remove_reaction(trans, reaction, user)
 
     async def on_reaction_clear(self, message, reactions):
         self.logger.debug(f"Reactions from {message.id} cleared")
@@ -196,7 +196,7 @@ class EventIngestionClient(discord.Client):
 
         self.logger.warn("TODO: handling for on_reaction_clear")
         #with self.sql.transaction() as trans:
-            #trans.clear_reactions(message)
+            #self.sql.clear_reactions(trans, message)
 
     async def on_guild_channel_create(self, channel):
         self.logger.debug(f"Channel was created in guild {channel.guild.id}")
@@ -206,7 +206,7 @@ class EventIngestionClient(discord.Client):
         self.logger.info(f"Channel #{channel.name} created in {channel.guild.name}")
 
         with self.sql.transaction() as trans:
-            trans.add_channel(channel)
+            self.sql.add_channel(trans, channel)
 
     async def on_guild_channel_delete(self, channel):
         self.logger.debug(f"Channel was deleted in guild {channel.guild.id}")
@@ -216,7 +216,7 @@ class EventIngestionClient(discord.Client):
         self.logger.info(f"Channel #{channel.name} deleted in {channel.guild.name}")
 
         with self.sql.transaction() as trans:
-            trans.remove_channel(channel)
+            self.sql.remove_channel(trans, channel)
 
     async def on_guild_channel_update(self, before, after):
         self.logger.debug(f"Channel was updated in guild {after.guild.id}")
@@ -230,7 +230,7 @@ class EventIngestionClient(discord.Client):
         self.logger.info(f"Channel #{before.name}{changed} was changed in {after.guild.name}")
 
         with self.sql.transaction() as trans:
-            trans.update_channel(after)
+            self.sql.update_channel(trans, after)
 
     async def on_guild_channel_pins_update(self, channel, last_pin):
         self.logger.debug(f"Channel {channel.id} got a pin update")
@@ -248,7 +248,7 @@ class EventIngestionClient(discord.Client):
         self.logger.info(f"Member {member.name} has joined {member.guild.name}")
 
         with self.sql.transaction() as trans:
-            trans.add_user(member)
+            self.sql.add_user(trans, member)
 
     async def on_member_remove(self, member):
         self.logger.debug(f"Member {member.id} left guild {member.guild.id}")
@@ -258,7 +258,7 @@ class EventIngestionClient(discord.Client):
         self.logger.info(f"Member {member.name} has left {member.guild.name}")
 
         with self.sql.transaction() as trans:
-            trans.remove_user(member)
+            self.sql.remove_user(trans, member)
 
     async def on_member_update(self, before, after):
         self.logger.debug(f"Member {after.id} was updated in guild {after.guild.id}")
@@ -279,7 +279,7 @@ class EventIngestionClient(discord.Client):
         self.logger.info(f"Member {before.name}{changed} was changed in {after.guild.name}")
 
         with self.sql.transaction() as trans:
-            trans.update_user(after)
+            self.sql.update_user(trans, after)
 
     async def on_guild_role_create(self, role):
         self.logger.debug(f"Role {role.id} was created in guild {role.guild.id}")
@@ -289,7 +289,7 @@ class EventIngestionClient(discord.Client):
         self.logger.info(f"Role {role.name} was created in {role.guild.name}")
 
         with self.sql.transaction() as trans:
-            self.sql.add_role(role)
+            self.sql.add_role(trans, role)
 
     async def on_guild_role_delete(self, role):
         self.logger.debug(f"Role {role.id} was created in guild {role.guild.id}")
@@ -299,7 +299,7 @@ class EventIngestionClient(discord.Client):
         self.logger.info(f"Role {role.name} was deleted in {role.guild.name}")
 
         with self.sql.transaction() as trans:
-            trans.remove_role(role)
+            self.sql.remove_role(trans, role)
 
     async def on_guild_role_update(self, before, after):
         self.logger.debug(f"Role {after.id} was created in guild {after.guild.id}")
@@ -313,7 +313,7 @@ class EventIngestionClient(discord.Client):
         self.logger.info(f"Role {before.name}{changed} was changed in {after.guild.name}")
 
         with self.sql.transaction() as trans:
-            trans.update_role(after)
+            self.sql.update_role(trans, after)
 
     async def on_guild_emojis_update(self, guild, before, after):
         before = set(before)
@@ -321,7 +321,7 @@ class EventIngestionClient(discord.Client):
 
         with self.sql.transaction() as trans:
             for emoji in after - before:
-                trans.add_emoji(emoji)
+                self.sql.add_emoji(trans, emoji)
             for emoji in before - after:
-                trans.remove_emoji(emoji)
+                self.sql.remove_emoji(trans, emoji)
 

--- a/statbot/client.py
+++ b/statbot/client.py
@@ -151,7 +151,7 @@ class EventIngestionClient(discord.Client):
         self._log(message, 'deleted')
 
         with self.sql.transaction():
-            self.sql.delete_message(message)
+            self.sql.remove_message(message)
 
     async def on_typing(self, channel, user, when):
         self.logger.debug(f"User id {user.id} is typing")
@@ -181,7 +181,7 @@ class EventIngestionClient(discord.Client):
         self._log_react(reaction, user, 'removed a reaction of ')
 
         with self.sql.transaction():
-            self.sql.delete_reaction(reaction, user)
+            self.sql.remove_reaction(reaction, user)
 
     async def on_reaction_clear(self, message, reactions):
         self.logger.debug(f"Reactions from {message.id} cleared")

--- a/statbot/client.py
+++ b/statbot/client.py
@@ -18,6 +18,7 @@ __all__ = [
 ]
 
 LOG_FULL_MESSAGES = False
+LOG_IGNORED_EVENTS = False
 
 from .sql import DiscordSqlHandler
 from .util import get_emoji_name, null_logger
@@ -46,16 +47,16 @@ class EventIngestionClient(discord.Client):
             self.logger.warn("Can't log message, not ready yet!")
             return False
         elif not hasattr(message, 'guild'):
-            self.logger.debug("Message not from a guild.")
-            self.logger.debug("Ignoring message.")
+            self._log_ignored("Message not from a guild.")
+            self._log_ignored("Ignoring message.")
             return False
         elif getattr(message.guild, 'id', None) not in self.config['guilds']:
-            self.logger.debug("Message from a guild we don't care about.")
-            self.logger.debug("Ignoring message.")
+            self._log_ignored("Message from a guild we don't care about.")
+            self._log_ignored("Ignoring message.")
             return False
         elif message.type != discord.MessageType.default:
-            self.logger.debug("Special type of message receieved.")
-            self.logger.debug("Ignoring message.")
+            self._log_ignored("Special type of message receieved.")
+            self._log_ignored("Ignoring message.")
         else:
             return True
 
@@ -64,11 +65,11 @@ class EventIngestionClient(discord.Client):
             self.logger.warn("Can't log event, not ready yet!")
             return False
         elif not hasattr(channel, 'guild'):
-            self.logger.debug("Channel not in a guild.")
-            self.logger.debug("Ignoring message.")
+            self._log_ignored("Channel not in a guild.")
+            self._log_ignored("Ignoring message.")
         elif getattr(channel.guild, 'id', None) not in self.config['guilds']:
-            self.logger.debug("Event from a guild we don't care about.")
-            self.logger.debug("Ignoring message.")
+            self._log_ignored("Event from a guild we don't care about.")
+            self._log_ignored("Ignoring message.")
             return False
         else:
             return True
@@ -78,8 +79,8 @@ class EventIngestionClient(discord.Client):
             self.logger.warn("Can't log event, not ready yet!")
             return False
         elif getattr(guild, 'id', None) not in self.config['guilds']:
-            self.logger.debug("Event from a guild we don't care about.")
-            self.logger.debug("Ignoring message.")
+            self._log_ignored("Event from a guild we don't care about.")
+            self._log_ignored("Ignoring message.")
             return False
         else:
             return True
@@ -110,6 +111,10 @@ class EventIngestionClient(discord.Client):
 
         self.logger.info(f"{name} {action} {emote} (total {count}) on message id {id}")
 
+    def _log_ignored(self, message):
+        if LOG_IGNORED_EVENTS:
+            self.logger.debug(message)
+
     async def on_ready(self):
         # Print welcome string
         self.logger.info(f"Logged in as {self.user.name} ({self.user.id})")
@@ -126,7 +131,7 @@ class EventIngestionClient(discord.Client):
         self.ready = True
 
     async def on_message(self, message):
-        self.logger.debug(f"Message id {message.id} created")
+        self._log_ignored(f"Message id {message.id} created")
         if not self._accept_message(message):
             return
 
@@ -136,7 +141,7 @@ class EventIngestionClient(discord.Client):
             self.sql.add_message(trans, message)
 
     async def on_message_edit(self, before, after):
-        self.logger.debug(f"Message id {after.id} edited")
+        self._log_ignored(f"Message id {after.id} edited")
         if not self._accept_message(after):
             return
 
@@ -146,7 +151,7 @@ class EventIngestionClient(discord.Client):
             self.sql.edit_message(trans, before, after)
 
     async def on_message_delete(self, message):
-        self.logger.debug(f"Message id {message.id} deleted")
+        self._log_ignored(f"Message id {message.id} deleted")
         if not self._accept_message(message):
             return
 
@@ -156,7 +161,7 @@ class EventIngestionClient(discord.Client):
             self.sql.remove_message(trans, message)
 
     async def on_typing(self, channel, user, when):
-        self.logger.debug(f"User id {user.id} is typing")
+        self._log_ignored(f"User id {user.id} is typing")
         if not self._accept_channel(channel):
             return
 
@@ -166,7 +171,7 @@ class EventIngestionClient(discord.Client):
             self.sql.typing(trans, channel, user, when)
 
     async def on_reaction_add(self, reaction, user):
-        self.logger.debug(f"Reaction {reaction.emoji} added")
+        self._log_ignored(f"Reaction {reaction.emoji} added")
         if not self._accept_message(reaction.message):
             return
 
@@ -177,7 +182,7 @@ class EventIngestionClient(discord.Client):
             #self.sql.add_reaction(trans, reaction, user)
 
     async def on_reaction_remove(self, reaction, user):
-        self.logger.debug(f"Reaction {reaction.emoji} removed")
+        self._log_ignored(f"Reaction {reaction.emoji} removed")
         if not self._accept_message(reaction.message):
             return
 
@@ -188,7 +193,7 @@ class EventIngestionClient(discord.Client):
             #self.sql.remove_reaction(trans, reaction, user)
 
     async def on_reaction_clear(self, message, reactions):
-        self.logger.debug(f"Reactions from {message.id} cleared")
+        self._log_ignored(f"Reactions from {message.id} cleared")
         if not self._accept_message(message):
             return
 
@@ -199,7 +204,7 @@ class EventIngestionClient(discord.Client):
             #self.sql.clear_reactions(trans, message)
 
     async def on_guild_channel_create(self, channel):
-        self.logger.debug(f"Channel was created in guild {channel.guild.id}")
+        self._log_ignored(f"Channel was created in guild {channel.guild.id}")
         if not self._accept_channel(channel):
             return
 
@@ -209,7 +214,7 @@ class EventIngestionClient(discord.Client):
             self.sql.add_channel(trans, channel)
 
     async def on_guild_channel_delete(self, channel):
-        self.logger.debug(f"Channel was deleted in guild {channel.guild.id}")
+        self._log_ignored(f"Channel was deleted in guild {channel.guild.id}")
         if not self._accept_channel(channel):
             return
 
@@ -219,7 +224,7 @@ class EventIngestionClient(discord.Client):
             self.sql.remove_channel(trans, channel)
 
     async def on_guild_channel_update(self, before, after):
-        self.logger.debug(f"Channel was updated in guild {after.guild.id}")
+        self._log_ignored(f"Channel was updated in guild {after.guild.id}")
         if not self._accept_channel(after):
             return
 
@@ -233,7 +238,7 @@ class EventIngestionClient(discord.Client):
             self.sql.update_channel(trans, after)
 
     async def on_guild_channel_pins_update(self, channel, last_pin):
-        self.logger.debug(f"Channel {channel.id} got a pin update")
+        self._log_ignored(f"Channel {channel.id} got a pin update")
         if not self._accept_channel(channel):
             return
 
@@ -241,7 +246,7 @@ class EventIngestionClient(discord.Client):
         self.logger.warn("TODO: handling for on_guild_channel_pins_update")
 
     async def on_member_join(self, member):
-        self.logger.debug(f"Member {member.id} joined guild {member.guild.id}")
+        self._log_ignored(f"Member {member.id} joined guild {member.guild.id}")
         if not self._accept_guild(member.guild):
             return
 
@@ -251,7 +256,7 @@ class EventIngestionClient(discord.Client):
             self.sql.add_user(trans, member)
 
     async def on_member_remove(self, member):
-        self.logger.debug(f"Member {member.id} left guild {member.guild.id}")
+        self._log_ignored(f"Member {member.id} left guild {member.guild.id}")
         if not self._accept_guild(member.guild):
             return
 
@@ -261,7 +266,7 @@ class EventIngestionClient(discord.Client):
             self.sql.remove_user(trans, member)
 
     async def on_member_update(self, before, after):
-        self.logger.debug(f"Member {after.id} was updated in guild {after.guild.id}")
+        self._log_ignored(f"Member {after.id} was updated in guild {after.guild.id}")
         if not self._accept_guild(after.guild):
             return
 
@@ -269,7 +274,7 @@ class EventIngestionClient(discord.Client):
         before.status = after.status
         before.game = after.game
         if before == after:
-            self.logger.debug("It was only a status change")
+            self._log_ignored("It was only a status change")
             return
 
         if before.name != after.name:
@@ -282,7 +287,7 @@ class EventIngestionClient(discord.Client):
             self.sql.update_user(trans, after)
 
     async def on_guild_role_create(self, role):
-        self.logger.debug(f"Role {role.id} was created in guild {role.guild.id}")
+        self._log_ignored(f"Role {role.id} was created in guild {role.guild.id}")
         if not self._accept_guild(role.guild):
             return
 
@@ -292,7 +297,7 @@ class EventIngestionClient(discord.Client):
             self.sql.add_role(trans, role)
 
     async def on_guild_role_delete(self, role):
-        self.logger.debug(f"Role {role.id} was created in guild {role.guild.id}")
+        self._log_ignored(f"Role {role.id} was created in guild {role.guild.id}")
         if not self._accept_guild(role.guild):
             return
 
@@ -302,7 +307,7 @@ class EventIngestionClient(discord.Client):
             self.sql.remove_role(trans, role)
 
     async def on_guild_role_update(self, before, after):
-        self.logger.debug(f"Role {after.id} was created in guild {after.guild.id}")
+        self._log_ignored(f"Role {after.id} was created in guild {after.guild.id}")
         if not self._accept_guild(after.guild):
             return
 

--- a/statbot/client.py
+++ b/statbot/client.py
@@ -132,8 +132,8 @@ class EventIngestionClient(discord.Client):
 
         self._log(message, 'created')
 
-        with self.sql.transaction():
-            self.sql.add_message(message)
+        with self.sql.transaction() as trans:
+            trans.add_message(message)
 
     async def on_message_edit(self, before, after):
         self.logger.debug(f"Message id {after.id} edited")
@@ -142,8 +142,8 @@ class EventIngestionClient(discord.Client):
 
         self._log(after, 'edited')
 
-        with self.sql.transaction():
-            self.sql.edit_message(before, after)
+        with self.sql.transaction() as trans:
+            trans.edit_message(before, after)
 
     async def on_message_delete(self, message):
         self.logger.debug(f"Message id {message.id} deleted")
@@ -152,8 +152,8 @@ class EventIngestionClient(discord.Client):
 
         self._log(message, 'deleted')
 
-        with self.sql.transaction():
-            self.sql.remove_message(message)
+        with self.sql.transaction() as trans:
+            trans.remove_message(message)
 
     async def on_typing(self, channel, user, when):
         self.logger.debug(f"User id {user.id} is typing")
@@ -162,8 +162,8 @@ class EventIngestionClient(discord.Client):
 
         self._log_typing(channel, user)
 
-        with self.sql.transaction():
-            self.sql.typing(channel, user, when)
+        with self.sql.transaction() as trans:
+            trans.typing(channel, user, when)
 
     async def on_reaction_add(self, reaction, user):
         self.logger.debug(f"Reaction {reaction.emoji} added")
@@ -173,8 +173,8 @@ class EventIngestionClient(discord.Client):
         self._log_react(reaction, user, 'reacted with')
 
         self.logger.warn("TODO: handling for on_reaction_add")
-        #with self.sql.transaction():
-            #self.sql.add_reaction(reaction, user)
+        #with self.sql.transaction() as trans:
+            #trans.add_reaction(reaction, user)
 
     async def on_reaction_remove(self, reaction, user):
         self.logger.debug(f"Reaction {reaction.emoji} removed")
@@ -184,8 +184,8 @@ class EventIngestionClient(discord.Client):
         self._log_react(reaction, user, 'removed a reaction of ')
 
         self.logger.warn("TODO: handling for on_reaction_remove")
-        #with self.sql.transaction():
-            #self.sql.remove_reaction(reaction, user)
+        #with self.sql.transaction() as trans:
+            #trans.remove_reaction(reaction, user)
 
     async def on_reaction_clear(self, message, reactions):
         self.logger.debug(f"Reactions from {message.id} cleared")
@@ -195,8 +195,8 @@ class EventIngestionClient(discord.Client):
         self.logger.info(f"All reactions on message id {message.id} cleared")
 
         self.logger.warn("TODO: handling for on_reaction_clear")
-        #with self.sql.transaction():
-            #self.sql.clear_reactions(message)
+        #with self.sql.transaction() as trans:
+            #trans.clear_reactions(message)
 
     async def on_guild_channel_create(self, channel):
         self.logger.debug(f"Channel was created in guild {channel.guild.id}")
@@ -205,8 +205,8 @@ class EventIngestionClient(discord.Client):
 
         self.logger.info(f"Channel #{channel.name} created in {channel.guild.name}")
 
-        with self.sql.transaction():
-            self.sql.add_channel(channel)
+        with self.sql.transaction() as trans:
+            trans.add_channel(channel)
 
     async def on_guild_channel_delete(self, channel):
         self.logger.debug(f"Channel was deleted in guild {channel.guild.id}")
@@ -215,8 +215,8 @@ class EventIngestionClient(discord.Client):
 
         self.logger.info(f"Channel #{channel.name} deleted in {channel.guild.name}")
 
-        with self.sql.transaction():
-            self.sql.remove_channel(channel)
+        with self.sql.transaction() as trans:
+            trans.remove_channel(channel)
 
     async def on_guild_channel_update(self, before, after):
         self.logger.debug(f"Channel was updated in guild {after.guild.id}")
@@ -229,8 +229,8 @@ class EventIngestionClient(discord.Client):
             changed = ''
         self.logger.info(f"Channel #{before.name}{changed} was changed in {after.guild.name}")
 
-        with self.sql.transaction():
-            self.sql.update_channel(after)
+        with self.sql.transaction() as trans:
+            trans.update_channel(after)
 
     async def on_guild_channel_pins_update(self, channel, last_pin):
         self.logger.debug(f"Channel {channel.id} got a pin update")
@@ -247,8 +247,8 @@ class EventIngestionClient(discord.Client):
 
         self.logger.info(f"Member {member.name} has joined {member.guild.name}")
 
-        with self.sql.transaction():
-            self.sql.add_user(member)
+        with self.sql.transaction() as trans:
+            trans.add_user(member)
 
     async def on_member_remove(self, member):
         self.logger.debug(f"Member {member.id} left guild {member.guild.id}")
@@ -257,8 +257,8 @@ class EventIngestionClient(discord.Client):
 
         self.logger.info(f"Member {member.name} has left {member.guild.name}")
 
-        with self.sql.transaction():
-            self.sql.remove_user(member)
+        with self.sql.transaction() as trans:
+            trans.remove_user(member)
 
     async def on_member_update(self, before, after):
         self.logger.debug(f"Member {after.id} was updated in guild {after.guild.id}")
@@ -278,8 +278,8 @@ class EventIngestionClient(discord.Client):
             changed = ''
         self.logger.info(f"Member {before.name}{changed} was changed in {after.guild.name}")
 
-        with self.sql.transaction():
-            self.sql.update_user(after)
+        with self.sql.transaction() as trans:
+            trans.update_user(after)
 
     async def on_guild_role_create(self, role):
         self.logger.debug(f"Role {role.id} was created in guild {role.guild.id}")
@@ -288,7 +288,7 @@ class EventIngestionClient(discord.Client):
 
         self.logger.info(f"Role {role.name} was created in {role.guild.name}")
 
-        with self.sql.transaction():
+        with self.sql.transaction() as trans:
             self.sql.add_role(role)
 
     async def on_guild_role_delete(self, role):
@@ -298,8 +298,8 @@ class EventIngestionClient(discord.Client):
 
         self.logger.info(f"Role {role.name} was deleted in {role.guild.name}")
 
-        with self.sql.transaction():
-            self.sql.remove_role(role)
+        with self.sql.transaction() as trans:
+            trans.remove_role(role)
 
     async def on_guild_role_update(self, before, after):
         self.logger.debug(f"Role {after.id} was created in guild {after.guild.id}")
@@ -312,16 +312,16 @@ class EventIngestionClient(discord.Client):
             changed = ''
         self.logger.info(f"Role {before.name}{changed} was changed in {after.guild.name}")
 
-        with self.sql.transaction():
-            self.sql.update_role(after)
+        with self.sql.transaction() as trans:
+            trans.update_role(after)
 
     async def on_guild_emojis_update(self, guild, before, after):
         before = set(before)
         after = set(before)
 
-        with self.sql.transaction():
+        with self.sql.transaction() as trans:
             for emoji in after - before:
-                self.sql.add_emoji(emoji)
+                trans.add_emoji(emoji)
             for emoji in before - after:
-                self.sql.remove_emoji(emoji)
+                trans.remove_emoji(emoji)
 

--- a/statbot/client.py
+++ b/statbot/client.py
@@ -230,7 +230,7 @@ class EventIngestionClient(discord.Client):
         self.logger.info(f"Channel #{before.name}{changed} was changed in {after.guild.name}")
 
         with self.sql.transaction():
-            self.sql.update_channel(before, after)
+            self.sql.update_channel(after)
 
     async def on_guild_channel_pins_update(self, channel, last_pin):
         self.logger.debug(f"Channel {channel.id} got a pin update")

--- a/statbot/client.py
+++ b/statbot/client.py
@@ -129,7 +129,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self._log(message, 'created')
-        self.sql.add_message(message)
+
+        with self.sql.transaction():
+            self.sql.add_message(message)
 
     async def on_message_edit(self, before, after):
         self.logger.debug(f"Message id {after.id} edited")
@@ -137,7 +139,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self._log(after, 'edited')
-        self.sql.edit_message(before, after)
+
+        with self.sql.transaction():
+            self.sql.edit_message(before, after)
 
     async def on_message_delete(self, message):
         self.logger.debug(f"Message id {message.id} deleted")
@@ -145,7 +149,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self._log(message, 'deleted')
-        self.sql.delete_message(message)
+
+        with self.sql.transaction():
+            self.sql.delete_message(message)
 
     async def on_typing(self, channel, user, when):
         self.logger.debug(f"User id {user.id} is typing")
@@ -153,7 +159,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self._log_typing(channel, user)
-        self.sql.typing(channel, user, when)
+
+        with self.sql.transaction():
+            self.sql.typing(channel, user, when)
 
     async def on_reaction_add(self, reaction, user):
         self.logger.debug(f"Reaction {reaction.emoji} added")
@@ -161,7 +169,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self._log_react(reaction, user, 'reacted with')
-        self.sql.add_reaction(reaction, user)
+
+        with self.sql.transaction():
+            self.sql.add_reaction(reaction, user)
 
     async def on_reaction_remove(self, reaction, user):
         self.logger.debug(f"Reaction {reaction.emoji} removed")
@@ -169,7 +179,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self._log_react(reaction, user, 'removed a reaction of ')
-        self.sql.delete_reaction(reaction, user)
+
+        with self.sql.transaction():
+            self.sql.delete_reaction(reaction, user)
 
     async def on_reaction_clear(self, message, reactions):
         self.logger.debug(f"Reactions from {message.id} cleared")
@@ -177,7 +189,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self.logger.info(f"All reactions on message id {message.id} cleared")
-        self.sql.clear_reactions(message)
+
+        with self.sql.transaction():
+            self.sql.clear_reactions(message)
 
     async def on_guild_channel_create(self, channel):
         self.logger.debug(f"Channel was created in guild {channel.guild.id}")
@@ -185,7 +199,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self.logger.info(f"Channel #{channel.name} created in {channel.guild.name}")
-        self.sql.add_channel(channel)
+
+        with self.sql.transaction():
+            self.sql.add_channel(channel)
 
     async def on_guild_channel_delete(self, channel):
         self.logger.debug(f"Channel was deleted in guild {channel.guild.id}")
@@ -193,7 +209,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self.logger.info(f"Channel #{channel.name} deleted in {channel.guild.name}")
-        self.sql.remove_channel(channel)
+
+        with self.sql.transaction():
+            self.sql.remove_channel(channel)
 
     async def on_guild_channel_update(self, before, after):
         self.logger.debug(f"Channel was updated in guild {after.guild.id}")
@@ -205,7 +223,9 @@ class EventIngestionClient(discord.Client):
         else:
             changed = ''
         self.logger.info(f"Channel #{before.name}{changed} was changed in {after.guild.name}")
-        self.sql.update_channel(before, after)
+
+        with self.sql.transaction():
+            self.sql.update_channel(before, after)
 
     async def on_guild_channel_pins_update(self, channel, last_pin):
         self.logger.debug(f"Channel {channel.id} got a pin update")
@@ -221,7 +241,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self.logger.info(f"Member {member.name} has joined {member.guild.name}")
-        self.sql.add_user(member)
+
+        with self.sql.transaction():
+            self.sql.add_user(member)
 
     async def on_member_remove(self, member):
         self.logger.debug(f"Member {member.id} left guild {member.guild.id}")
@@ -229,7 +251,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self.logger.info(f"Member {member.name} has left {member.guild.name}")
-        self.sql.remove_user(member)
+
+        with self.sql.transaction():
+            self.sql.remove_user(member)
 
     async def on_member_update(self, before, after):
         self.logger.debug(f"Member {after.id} was updated in guild {after.guild.id}")
@@ -248,7 +272,9 @@ class EventIngestionClient(discord.Client):
         else:
             changed = ''
         self.logger.info(f"Member {before.name}{changed} was changed in {after.guild.name}")
-        self.sql.update_user(after)
+
+        with self.sql.transaction():
+            self.sql.update_user(after)
 
     async def on_guild_role_create(self, role):
         self.logger.debug(f"Role {role.id} was created in guild {role.guild.id}")
@@ -256,7 +282,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self.logger.info(f"Role {role.name} was created in {role.guild.name}")
-        self.sql.add_role(role)
+
+        with self.sql.transaction():
+            self.sql.add_role(role)
 
     async def on_guild_role_delete(self, role):
         self.logger.debug(f"Role {role.id} was created in guild {role.guild.id}")
@@ -264,7 +292,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self.logger.info(f"Role {role.name} was deleted in {role.guild.name}")
-        self.sql.remove_role(role)
+
+        with self.sql.transaction():
+            self.sql.remove_role(role)
 
     async def on_guild_role_update(self, before, after):
         self.logger.debug(f"Role {after.id} was created in guild {after.guild.id}")
@@ -276,13 +306,17 @@ class EventIngestionClient(discord.Client):
         else:
             changed = ''
         self.logger.info(f"Role {before.name}{changed} was changed in {after.guild.name}")
-        self.sql.update_role(after)
+
+        with self.sql.transaction():
+            self.sql.update_role(after)
 
     async def on_guild_emojis_update(self, guild, before, after):
         before = set(before)
         after = set(before)
 
-        for emoji in after - before:
-            self.sql.add_emoji(emoji)
-        for emoji in before - after:
-            self.sql.remove_emoji(emoji)
+        with self.sql.transaction():
+            for emoji in after - before:
+                self.sql.add_emoji(emoji)
+            for emoji in before - after:
+                self.sql.remove_emoji(emoji)
+

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -52,10 +52,27 @@ class _Transaction:
 
     # For wrapping self.sql methods
     def __getattr__(self, name):
-        def wrapped(_, *args, **kwargs):
-            kwargs['trans'] = self
-            return getattr(self.sql, name)(*args, **kwargs)
+        def wrapped(*args, **kwargs):
+            sql_self = _SqlWrap(self.sql, self.execute)
+            return getattr(DiscordSqlHandler, name)(sql_self, *args, **kwargs)
         return wrapped
+
+    def execute(self, *args, **kwargs):
+        self.conn.execute(*args, **kwargs)
+
+class _SqlWrap:
+    def __init__(self, sql, execute):
+        self.sql = sql
+        def _execute(self, *args, **kwargs):
+            print("_SqlWrap execute()")
+            execute(*args, **kwargs)
+        self.execute = _execute
+
+    def __getattr__(self, name):
+        return getattr(self.sql, name)
+
+    def __repr__(self):
+        return f'_SqlWrap({self.sql!r})'
 
 class DiscordSqlHandler:
     '''
@@ -175,11 +192,9 @@ class DiscordSqlHandler:
     def transaction(self):
         return _Transaction(self)
 
-    def execute(self, trans, *args, **kwargs):
-        if trans is None:
-            self.db.execute(*args, **kwargs)
-        else:
-            trans.execute(*args, **kwargs)
+    def execute(self, *args, **kwargs):
+        print("db.execute() !!!!!!!!!")
+        self.db.execute(*args, **kwargs)
 
     # Value builders
     @staticmethod
@@ -247,7 +262,7 @@ class DiscordSqlHandler:
         }
 
     # Guild
-    def upsert_guild(self, guild, trans=None):
+    def upsert_guild(self, guild):
         values = self._guild_values(guild)
         if self.guild_cache.get(guild.id) == values:
             self.logger.debug(f"Guild lookup for {guild.id} is already up-to-date")
@@ -261,11 +276,11 @@ class DiscordSqlHandler:
                         index_where=(self.tb_guild_lookup.c.guild_id == guild.id),
                         set_=values,
                 )
-        self.execute(trans, ups)
+        self.execute(ups)
         self.guild_cache[guild.id] = values
 
     # Message
-    def add_message(self, message, trans=None):
+    def add_message(self, message):
         attach_urls = '\n'.join((attach.url for attach in message.attachments))
         if message.content:
             content = '\n'.join((message.content, attach_urls))
@@ -286,13 +301,14 @@ class DiscordSqlHandler:
                     'channel_id': message.channel.id,
                     'guild_id': message.guild.id,
                 })
-        self.execute(trans, ins)
+        self.execute(ins)
 
-        self.upsert_guild(message.guild, trans)
-        self.upsert_channel(message.channel, trans)
-        self.upsert_user(message.author, trans)
+        print(self)
+        self.upsert_guild(message.guild)
+        self.upsert_channel(message.channel)
+        self.upsert_user(message.author)
 
-    def edit_message(self, before, after, trans=None):
+    def edit_message(self, before, after):
         self.logger.info(f"Updating message {after.id}")
         upd = self.tb_messages \
                 .update() \
@@ -302,9 +318,9 @@ class DiscordSqlHandler:
                     'embeds': embeds_to_json(after.embeds),
                 }) \
                 .where(self.tb_messages.c.message_id == after.id)
-        self.execute(trans, upd)
+        self.execute(upd)
 
-    def remove_message(self, message, trans=None):
+    def remove_message(self, message):
         self.logger.info(f"Deleting message {message.id}")
         upd = self.tb_messages \
                 .update() \
@@ -312,14 +328,14 @@ class DiscordSqlHandler:
                     'is_deleted': True,
                 }) \
                 .where(self.tb_messages.c.message_id == message.id)
-        self.execute(trans, upd)
+        self.execute(upd)
 
-        self.upsert_guild(message.guild, trans)
-        self.upsert_channel(message.channel, trans)
-        self.upsert_user(message.author, trans)
+        self.upsert_guild(message.guild)
+        self.upsert_channel(message.channel)
+        self.upsert_user(message.author)
 
     # Typing
-    def typing(self, channel, user, when, trans=None):
+    def typing(self, channel, user, when):
         self.logger.info(f"Inserting typing event for user {user.id}")
         ins = self.tb_typing \
                 .insert() \
@@ -329,14 +345,14 @@ class DiscordSqlHandler:
                     'channel_id': channel.id,
                     'guild_id': channel.guild.id,
                 })
-        self.execute(trans, ins)
+        self.execute(ins)
 
-        self.upsert_guild(channel.guild, trans)
-        self.upsert_channel(channel, trans)
-        self.upsert_user(user, trans)
+        self.upsert_guild(channel.guild)
+        self.upsert_channel(channel)
+        self.upsert_user(user)
 
     # Reactions
-    def add_reaction(self, reaction, user, trans=None):
+    def add_reaction(self, reaction, user):
         self.logger.info(f"Inserting reaction for user {user.id} on message {reaction.message.id}")
         ins = self.tb_reactions \
                 .insert() \
@@ -347,34 +363,34 @@ class DiscordSqlHandler:
                     'channel_id': reaction.message.channel.id,
                     'guild_id': reaction.message.guild.id,
                 })
-        self.execute(trans, ins)
+        self.execute(ins)
 
-        self.upsert_guild(reaction.message.guild, trans)
-        self.upsert_channel(reaction.message.channel, trans)
-        self.upsert_user(user, trans)
+        self.upsert_guild(reaction.message.guild)
+        self.upsert_channel(reaction.message.channel)
+        self.upsert_user(user)
 
-    def remove_reaction(self, reaction, user, trans=None):
+    def remove_reaction(self, reaction, user):
         self.logger.info(f"Deleting reaction for user {user.id} on message {reaction.message.id}")
         delet = self.tb_reactions \
                 .delete() \
                 .where(self.tb_reactions.c.message_id == reaction.message.id) \
                 .where(self.tb_reactions.c.emoji_id == get_emoji_id(reaction.emoji)) \
                 .where(self.tb_reactions.c.user_id == user.id)
-        self.execute(trans, delet)
+        self.execute(delet)
 
-        self.upsert_guild(reaction.message.guild, trans)
-        self.upsert_channel(reaction.message.channel, trans)
-        self.upsert_user(user, trans)
+        self.upsert_guild(reaction.message.guild)
+        self.upsert_channel(reaction.message.channel)
+        self.upsert_user(user)
 
-    def clear_reactions(self, message, trans=None):
+    def clear_reactions(self, message):
         self.logger.info(f"Deleting all reactions on message {message.id}")
         delet = self.tb_reactions \
                 .delete() \
                 .where(self.tb_reactions.c.message_id == reaction.message.id)
-        self.execute(trans, delet)
+        self.execute(delet)
 
     # Pins (TODO)
-    def add_pin(self, announce, message, trans=None):
+    def add_pin(self, announce, message):
         raise NotImplementedError
 
         self.logger.info(f"Inserting pin for message {message.id}")
@@ -388,9 +404,9 @@ class DiscordSqlHandler:
                     'channel_id': message.channel.id,
                     'guild_id': message.guild.id,
                 })
-        self.execute(trans, ins)
+        self.execute(ins)
 
-    def remove_pin(self, announce, message, trans=None):
+    def remove_pin(self, announce, message):
         raise NotImplementedError
 
         self.logger.info(f"Deleting pin for message {message.id}")
@@ -398,10 +414,10 @@ class DiscordSqlHandler:
                 .delete() \
                 .where(self.tb_pins.c.pin_id == announce.id) \
                 .where(self.tb_pins.c.message_id == message.id)
-        self.execute(trans, delet)
+        self.execute(delet)
 
     # Roles
-    def add_role(self, role, trans=None):
+    def add_role(self, role):
         if role.id in self.role_cache:
             self.logger.debug(f"Role {role.id} already inserted.")
             return
@@ -411,23 +427,23 @@ class DiscordSqlHandler:
         ins = self.tb_role_lookup \
                 .insert() \
                 .values(values)
-        self.execute(trans, ins)
+        self.execute(ins)
         self.role_cache[role.id] = values
 
         self.upsert_guild(role.guild)
 
-    def remove_role(self, role, trans=None):
+    def remove_role(self, role):
         self.logger.info(f"Deleting role {role.id}")
         upd = self.tb_role_lookup \
                 .update() \
                 .values(is_deleted=True) \
                 .where(self.tb_role_lookup.c.role_id == role.id)
-        self.execute(trans, upd)
+        self.execute(upd)
         self.role_cache.pop(role.id, None)
 
-        self.upsert_guild(role.guild, trans)
+        self.upsert_guild(role.guild)
 
-    def upsert_role(self, role, trans=None):
+    def upsert_role(self, role):
         values = self._role_values(role)
         if self.role_cache.get(role.id) == values:
             self.logger.debug(f"Role lookup for {role.id} is already up-to-date")
@@ -441,13 +457,13 @@ class DiscordSqlHandler:
                         index_where=(self.tb_role_lookup.c.role_id == role.id),
                         set_=values,
                 )
-        self.execute(trans, ups)
+        self.execute(ups)
         self.role_cache[role.id] = values
 
-        self.upsert_guild(role.guild, trans)
+        self.upsert_guild(role.guild)
 
     # Channels
-    def add_channel(self, channel, trans=None):
+    def add_channel(self, channel):
         if channel.id in self.channel_cache:
             self.logger.debug(f"Channel {channel.id} already inserted.")
             return
@@ -457,10 +473,10 @@ class DiscordSqlHandler:
         ins = self.tb_channel_lookup \
                 .insert() \
                 .values(values)
-        self.execute(trans, ins)
+        self.execute(ins)
         self.channel_cache[channel.id] = values
 
-    def _update_channel(self, channel, trans):
+    def _update_channel(self, channel):
         self.logger.info(f"Updating channel {channel.id} in guild {guild.id}")
         values = self._channel_values(channel)
         upd = self.tb_channel_lookup \
@@ -470,13 +486,13 @@ class DiscordSqlHandler:
         self.execute(upd)
         self.channel_cache[channel.id] = values
 
-    def update_channel(self, channel, trans=None):
+    def update_channel(self, channel):
         if channel.id in self.channel_cache.keys():
-            self._update_channel(channel, trans)
+            self._update_channel(channel)
         else:
-            self.upsert_channel(channel, trans)
+            self.upsert_channel(channel)
 
-    def remove_channel(self, channel, trans=None):
+    def remove_channel(self, channel):
         self.logger.info(f"Deleting channel {channel.id} in guild {guild.id}")
         upd = self.tb_channel_lookup \
                 .update() \
@@ -485,7 +501,7 @@ class DiscordSqlHandler:
         self.execute(upd)
         self.channel_cache.pop(channel.id, None)
 
-    def upsert_channel(self, channel, trans=None):
+    def upsert_channel(self, channel):
         values = self._channel_values(channel)
         if self.channel_cache.get(channel.id) == values:
             self.logger.debug(f"Channel lookup for {channel.id} is already up-to-date")
@@ -499,11 +515,11 @@ class DiscordSqlHandler:
                         index_where=(self.tb_channel_lookup.c.channel_id == channel.id),
                         set_=values,
                 )
-        self.execute(trans, ups)
+        self.execute(ups)
         self.channel_cache[channel.id] = values
 
     # Users
-    def add_user(self, user, trans=None):
+    def add_user(self, user):
         if user.id in self.user_cache:
             self.logger.debug(f"User {user.id} already inserted.")
             return
@@ -513,26 +529,26 @@ class DiscordSqlHandler:
         ins = self.tb_user_lookup \
                 .insert() \
                 .values(values)
-        self.execute(trans, ins)
+        self.execute(ins)
         self.user_cache[user.id] = values
 
-    def _update_user(self, user, trans):
+    def _update_user(self, user):
         self.logger.info(f"Updating user {user.id}")
         values = self._user_values(user)
         upd = self.tb_user_lookup \
                 .update() \
                 .where(self.tb_user_lookup.c.user_id == user.id) \
                 .values(values)
-        self.execute(trans, upd)
+        self.execute(upd)
         self.user_cache[user.id] = values
 
-    def update_user(self, user, trans=None):
+    def update_user(self, user):
         if user.id in self.user_cache.keys():
-            self._update_user(user, trans)
+            self._update_user(user)
         else:
-            self.upsert_user(user, trans)
+            self.upsert_user(user)
 
-    def remove_user(self, user, trans=None):
+    def remove_user(self, user):
         self.logger.info(f"Removing user {user.id}")
         upd = self.tb_user_lookup \
                 .update() \
@@ -541,7 +557,7 @@ class DiscordSqlHandler:
         self.execute(upd)
         self.user_cache.pop(user.id, None)
 
-    def upsert_user(self, user, trans=None):
+    def upsert_user(self, user):
         values = self._user_values(user)
         if self.user_cache.get(user.id) == values:
             self.logger.debug(f"User lookup for {user.id} is already up-to-date")
@@ -554,11 +570,11 @@ class DiscordSqlHandler:
                         index_where=(self.tb_user_lookup.c.user_id == user.id),
                         set_=values,
                 )
-        self.execute(trans, ups)
+        self.execute(ups)
         self.user_cache[user.id] = values
 
     # Emojis (TODO)
-    def add_emoji(self, emoji, trans=None):
+    def add_emoji(self, emoji):
         raise NotImplementedError
 
         values = self._emoji_values(emoji)
@@ -571,10 +587,10 @@ class DiscordSqlHandler:
         ins = self.tb_emoji_lookup \
                 .insert() \
                 .values(value)
-        self.execute(trans, ins)
+        self.execute(ins)
         self.emoji_cache[id] = values
 
-    def remove_emoji(self, emoji, trans=None):
+    def remove_emoji(self, emoji):
         raise NotImplementedError
 
         id = get_emoji_id(emoji)
@@ -583,10 +599,10 @@ class DiscordSqlHandler:
                 .update() \
                 .values(is_deleted=True) \
                 .where(self.tb_emoji_lookup.c.emoji_id == id)
-        self.execute(trans, upd)
+        self.execute(upd)
         self.emoji_cache.pop(id, None)
 
-    def upsert_emoji(self, emoji, trans=None):
+    def upsert_emoji(self, emoji):
         raise NotImplementedError
 
         values = self._emoji_values(emoji)
@@ -602,6 +618,6 @@ class DiscordSqlHandler:
                         index_where=(self.tb_emoji_lookup.c.emoji_id == id),
                         set_=values,
                     )
-        self.execute(trans, ups)
+        self.execute(ups)
         self.emoji_cache[id] = values
 

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -293,7 +293,7 @@ class DiscordSqlHandler:
                 .where(self.tb_messages.c.message_id == after.id)
         self.execute(upd)
 
-    def delete_message(self, message):
+    def remove_message(self, message):
         self.logger.info(f"Deleting message {message.id}")
         upd = self.tb_messages \
                 .update() \
@@ -343,7 +343,7 @@ class DiscordSqlHandler:
         self.upsert_user(user)
         self.upsert_emoji(reaction.emoji)
 
-    def delete_reaction(self, reaction, user):
+    def remove_reaction(self, reaction, user):
         self.logger.info(f"Deleting reaction for user {user.id} on message {message.id}")
         delet = self.tb_reactions \
                 .delete() \

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -35,20 +35,17 @@ class _Transaction:
         self.trans = None
 
     def __enter__(self):
-        ## DEBUG
-        self.logger.info("Starting transaction...")
+        self.logger.debug("Starting transaction...")
         self.trans = self.sql.conn.begin()
         return self.sql
 
     def __exit__(self, type, value, traceback):
         if (type, value, traceback) == (None, None, None):
-            ## DEBUG
-            self.logger.info("Committing transaction...")
+            self.logger.debug("Committing transaction...")
             self.trans.commit()
         else:
             self.logger.error("Exception occurred in 'with' scope!")
-            ## DEBUG
-            self.logger.info("Rolling back transaction...")
+            self.logger.debug("Rolling back transaction...")
             self.trans.rollback()
 
 class DiscordSqlHandler:

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -406,6 +406,22 @@ class DiscordSqlHandler:
 
         self.upsert_guild(trans, role.guild)
 
+    def _update_role(self, trans, role):
+        self.logger.info(f"Updating role {role.id} in guild {role.guild.id}")
+        values = self._role_values(role)
+        upd = self.tb_role_lookup \
+                .update() \
+                .where(self.tb_role_lookup.c.role_id == role.id) \
+                .values(values)
+        trans.execute(upd)
+        self.role_cache[role.id] = values
+
+    def update_role(self, trans, role):
+        if role.id in self.role_cache:
+            self._update_role(self, role)
+        else:
+            self.upsert_role(self, role)
+
     def remove_role(self, trans, role):
         self.logger.info(f"Deleting role {role.id}")
         upd = self.tb_role_lookup \
@@ -461,7 +477,7 @@ class DiscordSqlHandler:
         self.channel_cache[channel.id] = values
 
     def update_channel(self, trans, channel):
-        if channel.id in self.channel_cache.keys():
+        if channel.id in self.channel_cache:
             self._update_channel(trans, channel)
         else:
             self.upsert_channel(trans, channel)
@@ -517,7 +533,7 @@ class DiscordSqlHandler:
         self.user_cache[user.id] = values
 
     def update_user(self, trans, user):
-        if user.id in self.user_cache.keys():
+        if user.id in self.user_cache:
             self._update_user(trans, user)
         else:
             self.upsert_user(trans, user)

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -467,7 +467,7 @@ class DiscordSqlHandler:
         self.channel_cache[channel.id] = values
 
     def _update_channel(self, trans, channel):
-        self.logger.info(f"Updating channel {channel.id} in guild {guild.id}")
+        self.logger.info(f"Updating channel {channel.id} in guild {channel.guild.id}")
         values = self._channel_values(channel)
         upd = self.tb_channel_lookup \
                 .update() \

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -344,7 +344,7 @@ class DiscordSqlHandler:
         self.upsert_emoji(reaction.emoji)
 
     def remove_reaction(self, reaction, user):
-        self.logger.info(f"Deleting reaction for user {user.id} on message {message.id}")
+        self.logger.info(f"Deleting reaction for user {user.id} on message {reaction.message.id}")
         delet = self.tb_reactions \
                 .delete() \
                 .where(self.tb_reactions.c.message_id == reaction.message.id) \

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -278,10 +278,9 @@ class DiscordSqlHandler:
                 })
         trans.execute(ins)
 
-        print(self)
-        self.upsert_guild(message.guild)
-        self.upsert_channel(message.channel)
-        self.upsert_user(message.author)
+        self.upsert_guild(trans, message.guild)
+        self.upsert_channel(trans, message.channel)
+        self.upsert_user(trans, message.author)
 
     def edit_message(self, trans, before, after):
         self.logger.info(f"Updating message {after.id}")
@@ -305,9 +304,9 @@ class DiscordSqlHandler:
                 .where(self.tb_messages.c.message_id == message.id)
         trans.execute(upd)
 
-        self.upsert_guild(message.guild)
-        self.upsert_channel(message.channel)
-        self.upsert_user(message.author)
+        self.upsert_guild(trans, message.guild)
+        self.upsert_channel(trans, message.channel)
+        self.upsert_user(trans, message.author)
 
     # Typing
     def typing(self, trans, channel, user, when):
@@ -322,9 +321,9 @@ class DiscordSqlHandler:
                 })
         trans.execute(ins)
 
-        self.upsert_guild(channel.guild)
-        self.upsert_channel(channel)
-        self.upsert_user(user)
+        self.upsert_guild(trans, channel.guild)
+        self.upsert_channel(trans, channel)
+        self.upsert_user(trans, user)
 
     # Reactions
     def add_reaction(self, trans, reaction, user):
@@ -340,9 +339,9 @@ class DiscordSqlHandler:
                 })
         trans.execute(ins)
 
-        self.upsert_guild(reaction.message.guild)
-        self.upsert_channel(reaction.message.channel)
-        self.upsert_user(user)
+        self.upsert_guild(trans, reaction.message.guild)
+        self.upsert_channel(trans, reaction.message.channel)
+        self.upsert_user(trans, user)
 
     def remove_reaction(self, trans, reaction, user):
         self.logger.info(f"Deleting reaction for user {user.id} on message {reaction.message.id}")
@@ -353,9 +352,9 @@ class DiscordSqlHandler:
                 .where(self.tb_reactions.c.user_id == user.id)
         trans.execute(delet)
 
-        self.upsert_guild(reaction.message.guild)
-        self.upsert_channel(reaction.message.channel)
-        self.upsert_user(user)
+        self.upsert_guild(trans, reaction.message.guild)
+        self.upsert_channel(trans, reaction.message.channel)
+        self.upsert_user(trans, user)
 
     def clear_reactions(self, trans, message):
         self.logger.info(f"Deleting all reactions on message {message.id}")
@@ -461,7 +460,7 @@ class DiscordSqlHandler:
         trans.execute(upd)
         self.channel_cache[channel.id] = values
 
-    def update_channel(self, trans channel):
+    def update_channel(self, trans, channel):
         if channel.id in self.channel_cache.keys():
             self._update_channel(trans, channel)
         else:

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -174,8 +174,11 @@ class DiscordSqlHandler:
     def transaction(self):
         return _Transaction(self)
 
-    def execute(self, *args, **kwargs):
-        self.conn.execute(*args, **kwargs)
+    def execute(self, trans, *args, **kwargs):
+        if trans is None:
+            self.db.execute(*args, **kwargs)
+        else:
+            trans.execute(*args, **kwargs)
 
     # Value builders
     @staticmethod
@@ -243,7 +246,7 @@ class DiscordSqlHandler:
         }
 
     # Guild
-    def upsert_guild(self, guild):
+    def upsert_guild(self, guild, trans=None):
         values = self._guild_values(guild)
         if self.guild_cache.get(guild.id) == values:
             self.logger.debug(f"Guild lookup for {guild.id} is already up-to-date")
@@ -257,11 +260,11 @@ class DiscordSqlHandler:
                         index_where=(self.tb_guild_lookup.c.guild_id == guild.id),
                         set_=values,
                 )
-        self.execute(ups)
+        self.execute(trans, ups)
         self.guild_cache[guild.id] = values
 
     # Message
-    def add_message(self, message):
+    def add_message(self, message, trans=None):
         attach_urls = '\n'.join((attach.url for attach in message.attachments))
         if message.content:
             content = '\n'.join((message.content, attach_urls))
@@ -282,13 +285,13 @@ class DiscordSqlHandler:
                     'channel_id': message.channel.id,
                     'guild_id': message.guild.id,
                 })
-        self.execute(ins)
+        self.execute(trans, ins)
 
-        self.upsert_guild(message.guild)
-        self.upsert_channel(message.channel)
-        self.upsert_user(message.author)
+        self.upsert_guild(message.guild, trans)
+        self.upsert_channel(message.channel, trans)
+        self.upsert_user(message.author, trans)
 
-    def edit_message(self, before, after):
+    def edit_message(self, before, after, trans=None):
         self.logger.info(f"Updating message {after.id}")
         upd = self.tb_messages \
                 .update() \
@@ -298,9 +301,9 @@ class DiscordSqlHandler:
                     'embeds': embeds_to_json(after.embeds),
                 }) \
                 .where(self.tb_messages.c.message_id == after.id)
-        self.execute(upd)
+        self.execute(trans, upd)
 
-    def remove_message(self, message):
+    def remove_message(self, message, trans=None):
         self.logger.info(f"Deleting message {message.id}")
         upd = self.tb_messages \
                 .update() \
@@ -308,14 +311,14 @@ class DiscordSqlHandler:
                     'is_deleted': True,
                 }) \
                 .where(self.tb_messages.c.message_id == message.id)
-        self.execute(upd)
+        self.execute(trans, upd)
 
-        self.upsert_guild(message.guild)
-        self.upsert_channel(message.channel)
-        self.upsert_user(message.author)
+        self.upsert_guild(message.guild, trans)
+        self.upsert_channel(message.channel, trans)
+        self.upsert_user(message.author, trans)
 
     # Typing
-    def typing(self, channel, user, when):
+    def typing(self, channel, user, when, trans=None):
         self.logger.info(f"Inserting typing event for user {user.id}")
         ins = self.tb_typing \
                 .insert() \
@@ -325,14 +328,14 @@ class DiscordSqlHandler:
                     'channel_id': channel.id,
                     'guild_id': channel.guild.id,
                 })
-        self.execute(ins)
+        self.execute(trans, ins)
 
-        self.upsert_guild(channel.guild)
-        self.upsert_channel(channel)
-        self.upsert_user(user)
+        self.upsert_guild(channel.guild, trans)
+        self.upsert_channel(channel, trans)
+        self.upsert_user(user, trans)
 
     # Reactions
-    def add_reaction(self, reaction, user):
+    def add_reaction(self, reaction, user, trans=None):
         self.logger.info(f"Inserting reaction for user {user.id} on message {reaction.message.id}")
         ins = self.tb_reactions \
                 .insert() \
@@ -343,36 +346,34 @@ class DiscordSqlHandler:
                     'channel_id': reaction.message.channel.id,
                     'guild_id': reaction.message.guild.id,
                 })
-        self.execute(ins)
+        self.execute(trans, ins)
 
-        self.upsert_guild(reaction.message.guild)
-        self.upsert_channel(reaction.message.channel)
-        self.upsert_user(user)
-        #self.upsert_emoji(reaction.emoji)
+        self.upsert_guild(reaction.message.guild, trans)
+        self.upsert_channel(reaction.message.channel, trans)
+        self.upsert_user(user, trans)
 
-    def remove_reaction(self, reaction, user):
+    def remove_reaction(self, reaction, user, trans=None):
         self.logger.info(f"Deleting reaction for user {user.id} on message {reaction.message.id}")
         delet = self.tb_reactions \
                 .delete() \
                 .where(self.tb_reactions.c.message_id == reaction.message.id) \
                 .where(self.tb_reactions.c.emoji_id == get_emoji_id(reaction.emoji)) \
                 .where(self.tb_reactions.c.user_id == user.id)
-        self.execute(delet)
+        self.execute(trans, delet)
 
-        self.upsert_guild(reaction.message.guild)
-        self.upsert_channel(reaction.message.channel)
-        self.upsert_user(user)
-        #self.upsert_emoji(reaction.emoji)
+        self.upsert_guild(reaction.message.guild, trans)
+        self.upsert_channel(reaction.message.channel, trans)
+        self.upsert_user(user, trans)
 
-    def clear_reactions(self, message):
+    def clear_reactions(self, message, trans=None):
         self.logger.info(f"Deleting all reactions on message {message.id}")
         delet = self.tb_reactions \
                 .delete() \
                 .where(self.tb_reactions.c.message_id == reaction.message.id)
-        self.execute(delet)
+        self.execute(trans, delet)
 
     # Pins (TODO)
-    def add_pin(self, announce, message):
+    def add_pin(self, announce, message, trans=None):
         raise NotImplementedError
 
         self.logger.info(f"Inserting pin for message {message.id}")
@@ -386,9 +387,9 @@ class DiscordSqlHandler:
                     'channel_id': message.channel.id,
                     'guild_id': message.guild.id,
                 })
-        self.execute(ins)
+        self.execute(trans, ins)
 
-    def remove_pin(self, announce, message):
+    def remove_pin(self, announce, message, trans=None):
         raise NotImplementedError
 
         self.logger.info(f"Deleting pin for message {message.id}")
@@ -396,10 +397,10 @@ class DiscordSqlHandler:
                 .delete() \
                 .where(self.tb_pins.c.pin_id == announce.id) \
                 .where(self.tb_pins.c.message_id == message.id)
-        self.execute(delet)
+        self.execute(trans, delet)
 
     # Roles
-    def add_role(self, role):
+    def add_role(self, role, trans=None):
         if role.id in self.role_cache:
             self.logger.debug(f"Role {role.id} already inserted.")
             return
@@ -409,23 +410,23 @@ class DiscordSqlHandler:
         ins = self.tb_role_lookup \
                 .insert() \
                 .values(values)
-        self.execute(ins)
+        self.execute(trans, ins)
         self.role_cache[role.id] = values
 
         self.upsert_guild(role.guild)
 
-    def remove_role(self, role):
+    def remove_role(self, role, trans=None):
         self.logger.info(f"Deleting role {role.id}")
         upd = self.tb_role_lookup \
                 .update() \
                 .values(is_deleted=True) \
                 .where(self.tb_role_lookup.c.role_id == role.id)
-        self.execute(upd)
+        self.execute(trans, upd)
         self.role_cache.pop(role.id, None)
 
-        self.upsert_guild(role.guild)
+        self.upsert_guild(role.guild, trans)
 
-    def upsert_role(self, role):
+    def upsert_role(self, role, trans=None):
         values = self._role_values(role)
         if self.role_cache.get(role.id) == values:
             self.logger.debug(f"Role lookup for {role.id} is already up-to-date")
@@ -439,13 +440,13 @@ class DiscordSqlHandler:
                         index_where=(self.tb_role_lookup.c.role_id == role.id),
                         set_=values,
                 )
-        self.execute(ups)
+        self.execute(trans, ups)
         self.role_cache[role.id] = values
 
-        self.upsert_guild(role.guild)
+        self.upsert_guild(role.guild, trans)
 
     # Channels
-    def add_channel(self, channel):
+    def add_channel(self, channel, trans=None):
         if channel.id in self.channel_cache:
             self.logger.debug(f"Channel {channel.id} already inserted.")
             return
@@ -455,10 +456,10 @@ class DiscordSqlHandler:
         ins = self.tb_channel_lookup \
                 .insert() \
                 .values(values)
-        self.execute(ins)
+        self.execute(trans, ins)
         self.channel_cache[channel.id] = values
 
-    def _update_channel(self, channel):
+    def _update_channel(self, channel, trans):
         self.logger.info(f"Updating channel {channel.id} in guild {guild.id}")
         values = self._channel_values(channel)
         upd = self.tb_channel_lookup \
@@ -468,13 +469,13 @@ class DiscordSqlHandler:
         self.execute(upd)
         self.channel_cache[channel.id] = values
 
-    def update_channel(self, channel):
+    def update_channel(self, channel, trans=None):
         if channel.id in self.channel_cache.keys():
-            self._update_channel(channel)
+            self._update_channel(channel, trans)
         else:
-            self.upsert_channel(channel)
+            self.upsert_channel(channel, trans)
 
-    def remove_channel(self, channel):
+    def remove_channel(self, channel, trans=None):
         self.logger.info(f"Deleting channel {channel.id} in guild {guild.id}")
         upd = self.tb_channel_lookup \
                 .update() \
@@ -483,7 +484,7 @@ class DiscordSqlHandler:
         self.execute(upd)
         self.channel_cache.pop(channel.id, None)
 
-    def upsert_channel(self, channel):
+    def upsert_channel(self, channel, trans=None):
         values = self._channel_values(channel)
         if self.channel_cache.get(channel.id) == values:
             self.logger.debug(f"Channel lookup for {channel.id} is already up-to-date")
@@ -497,11 +498,11 @@ class DiscordSqlHandler:
                         index_where=(self.tb_channel_lookup.c.channel_id == channel.id),
                         set_=values,
                 )
-        self.execute(ups)
+        self.execute(trans, ups)
         self.channel_cache[channel.id] = values
 
     # Users
-    def add_user(self, user):
+    def add_user(self, user, trans=None):
         if user.id in self.user_cache:
             self.logger.debug(f"User {user.id} already inserted.")
             return
@@ -511,26 +512,26 @@ class DiscordSqlHandler:
         ins = self.tb_user_lookup \
                 .insert() \
                 .values(values)
-        self.execute(ins)
+        self.execute(trans, ins)
         self.user_cache[user.id] = values
 
-    def _update_user(self, user):
+    def _update_user(self, user, trans):
         self.logger.info(f"Updating user {user.id}")
         values = self._user_values(user)
         upd = self.tb_user_lookup \
                 .update() \
                 .where(self.tb_user_lookup.c.user_id == user.id) \
                 .values(values)
-        self.execute(upd)
+        self.execute(trans, upd)
         self.user_cache[user.id] = values
 
-    def update_user(self, user):
+    def update_user(self, user, trans=None):
         if user.id in self.user_cache.keys():
-            self._update_user(user)
+            self._update_user(user, trans)
         else:
-            self.upsert_user(user)
+            self.upsert_user(user, trans)
 
-    def remove_user(self, user):
+    def remove_user(self, user, trans=None):
         self.logger.info(f"Removing user {user.id}")
         upd = self.tb_user_lookup \
                 .update() \
@@ -539,7 +540,7 @@ class DiscordSqlHandler:
         self.execute(upd)
         self.user_cache.pop(user.id, None)
 
-    def upsert_user(self, user):
+    def upsert_user(self, user, trans=None):
         values = self._user_values(user)
         if self.user_cache.get(user.id) == values:
             self.logger.debug(f"User lookup for {user.id} is already up-to-date")
@@ -552,11 +553,11 @@ class DiscordSqlHandler:
                         index_where=(self.tb_user_lookup.c.user_id == user.id),
                         set_=values,
                 )
-        self.execute(ups)
+        self.execute(trans, ups)
         self.user_cache[user.id] = values
 
     # Emojis (TODO)
-    def add_emoji(self, emoji):
+    def add_emoji(self, emoji, trans=None):
         raise NotImplementedError
 
         values = self._emoji_values(emoji)
@@ -569,10 +570,10 @@ class DiscordSqlHandler:
         ins = self.tb_emoji_lookup \
                 .insert() \
                 .values(value)
-        self.execute(ins)
+        self.execute(trans, ins)
         self.emoji_cache[id] = values
 
-    def remove_emoji(self, emoji):
+    def remove_emoji(self, emoji, trans=None):
         raise NotImplementedError
 
         id = get_emoji_id(emoji)
@@ -581,10 +582,10 @@ class DiscordSqlHandler:
                 .update() \
                 .values(is_deleted=True) \
                 .where(self.tb_emoji_lookup.c.emoji_id == id)
-        self.execute(upd)
+        self.execute(trans, upd)
         self.emoji_cache.pop(id, None)
 
-    def upsert_emoji(self, emoji):
+    def upsert_emoji(self, emoji, trans=None):
         raise NotImplementedError
 
         values = self._emoji_values(emoji)
@@ -600,6 +601,6 @@ class DiscordSqlHandler:
                         index_where=(self.tb_emoji_lookup.c.emoji_id == id),
                         set_=values,
                     )
-        self.execute(ups)
+        self.execute(trans, ups)
         self.emoji_cache[id] = values
 

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -22,6 +22,35 @@ __all__ = [
     'DiscordSqlHandler',
 ]
 
+class _Transaction:
+    __slots__ = (
+        'sql',
+        'trans',
+        'logger',
+    )
+
+    def __init__(self, sql):
+        self.sql = sql
+        self.logger = sql.logger
+        self.trans = None
+
+    def __enter__(self):
+        ## DEBUG
+        self.logger.info("Starting transaction...")
+        self.trans = self.sql.conn.begin()
+        return self.sql
+
+    def __exit__(self, type, value, traceback):
+        if (type, value, traceback) == (None, None, None):
+            ## DEBUG
+            self.logger.info("Committing transaction...")
+            self.trans.commit()
+        else:
+            self.logger.error("Exception occurred in 'with' scope!")
+            ## DEBUG
+            self.logger.info("Rolling back transaction...")
+            self.trans.rollback()
+
 class DiscordSqlHandler:
     '''
     An abstract handling class that bridges the gap between


### PR DESCRIPTION
Fixes #1 

This allows anybody with a `sql` handle to be able to do:
```python
with sql.transaction() as trans:
   sql.do_thing(trans, ...)
   sql.do_another_thing(trans, ...)
```

Also ensures that all internal `sql` methods use the correct context for this.