### PR TITLE
Locking

### DIFF
--- a/statbot/client.py
+++ b/statbot/client.py
@@ -131,7 +131,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self._log(message, 'created')
-        self.sql.add_message(message)
+
+        with self.sql.transaction():
+            self.sql.add_message(message)
 
     async def on_message_edit(self, before, after):
         self.logger.debug(f"Message id {after.id} edited")
@@ -139,7 +141,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self._log(after, 'edited')
-        self.sql.edit_message(before, after)
+
+        with self.sql.transaction():
+            self.sql.edit_message(before, after)
 
     async def on_message_delete(self, message):
         self.logger.debug(f"Message id {message.id} deleted")
@@ -147,7 +151,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self._log(message, 'deleted')
-        self.sql.delete_message(message)
+
+        with self.sql.transaction():
+            self.sql.remove_message(message)
 
     async def on_typing(self, channel, user, when):
         self.logger.debug(f"User id {user.id} is typing")
@@ -155,7 +161,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self._log_typing(channel, user)
-        self.sql.typing(channel, user, when)
+
+        with self.sql.transaction():
+            self.sql.typing(channel, user, when)
 
     async def on_reaction_add(self, reaction, user):
         self.logger.debug(f"Reaction {reaction.emoji} added")
@@ -163,8 +171,10 @@ class EventIngestionClient(discord.Client):
             return
 
         self._log_react(reaction, user, 'reacted with')
+
         self.logger.warn("TODO: handling for on_reaction_add")
-        #self.sql.add_reaction(reaction, user)
+        #with self.sql.transaction():
+            #self.sql.add_reaction(reaction, user)
 
     async def on_reaction_remove(self, reaction, user):
         self.logger.debug(f"Reaction {reaction.emoji} removed")
@@ -172,8 +182,10 @@ class EventIngestionClient(discord.Client):
             return
 
         self._log_react(reaction, user, 'removed a reaction of ')
+
         self.logger.warn("TODO: handling for on_reaction_remove")
-        #self.sql.delete_reaction(reaction, user)
+        #with self.sql.transaction():
+            #self.sql.remove_reaction(reaction, user)
 
     async def on_reaction_clear(self, message, reactions):
         self.logger.debug(f"Reactions from {message.id} cleared")
@@ -181,8 +193,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self.logger.info(f"All reactions on message id {message.id} cleared")
-        self.logger.warn("TODO: handling for on_reaction_clear")
-        #self.sql.clear_reactions(message)
+
+        #with self.sql.transaction():
+            #self.sql.clear_reactions(message)
 
     async def on_guild_channel_create(self, channel):
         self.logger.debug(f"Channel was created in guild {channel.guild.id}")
@@ -190,7 +203,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self.logger.info(f"Channel #{channel.name} created in {channel.guild.name}")
-        self.sql.add_channel(channel)
+
+        with self.sql.transaction():
+            self.sql.add_channel(channel)
 
     async def on_guild_channel_delete(self, channel):
         self.logger.debug(f"Channel was deleted in guild {channel.guild.id}")
@@ -198,7 +213,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self.logger.info(f"Channel #{channel.name} deleted in {channel.guild.name}")
-        self.sql.remove_channel(channel)
+
+        with self.sql.transaction():
+            self.sql.remove_channel(channel)
 
     async def on_guild_channel_update(self, before, after):
         self.logger.debug(f"Channel was updated in guild {after.guild.id}")
@@ -210,7 +227,9 @@ class EventIngestionClient(discord.Client):
         else:
             changed = ''
         self.logger.info(f"Channel #{before.name}{changed} was changed in {after.guild.name}")
-        self.sql.update_channel(before, after)
+
+        with self.sql.transaction():
+            self.sql.update_channel(before, after)
 
     async def on_guild_channel_pins_update(self, channel, last_pin):
         self.logger.debug(f"Channel {channel.id} got a pin update")
@@ -226,7 +245,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self.logger.info(f"Member {member.name} has joined {member.guild.name}")
-        self.sql.add_user(member)
+
+        with self.sql.transaction():
+            self.sql.add_user(member)
 
     async def on_member_remove(self, member):
         self.logger.debug(f"Member {member.id} left guild {member.guild.id}")
@@ -234,7 +255,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self.logger.info(f"Member {member.name} has left {member.guild.name}")
-        self.sql.remove_user(member)
+
+        with self.sql.transaction():
+            self.sql.remove_user(member)
 
     async def on_member_update(self, before, after):
         self.logger.debug(f"Member {after.id} was updated in guild {after.guild.id}")
@@ -253,7 +276,9 @@ class EventIngestionClient(discord.Client):
         else:
             changed = ''
         self.logger.info(f"Member {before.name}{changed} was changed in {after.guild.name}")
-        self.sql.update_user(after)
+
+        with self.sql.transaction():
+            self.sql.update_user(after)
 
     async def on_guild_role_create(self, role):
         self.logger.debug(f"Role {role.id} was created in guild {role.guild.id}")
@@ -261,7 +286,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self.logger.info(f"Role {role.name} was created in {role.guild.name}")
-        self.sql.add_role(role)
+
+        with self.sql.transaction():
+            self.sql.add_role(role)
 
     async def on_guild_role_delete(self, role):
         self.logger.debug(f"Role {role.id} was created in guild {role.guild.id}")
@@ -269,7 +296,9 @@ class EventIngestionClient(discord.Client):
             return
 
         self.logger.info(f"Role {role.name} was deleted in {role.guild.name}")
-        self.sql.remove_role(role)
+
+        with self.sql.transaction():
+            self.sql.remove_role(role)
 
     async def on_guild_role_update(self, before, after):
         self.logger.debug(f"Role {after.id} was created in guild {after.guild.id}")
@@ -281,13 +310,17 @@ class EventIngestionClient(discord.Client):
         else:
             changed = ''
         self.logger.info(f"Role {before.name}{changed} was changed in {after.guild.name}")
-        self.sql.update_role(after)
+
+        with self.sql.transaction():
+            self.sql.update_role(after)
 
     async def on_guild_emojis_update(self, guild, before, after):
         before = set(before)
         after = set(before)
 
-        for emoji in after - before:
-            self.sql.add_emoji(emoji)
-        for emoji in before - after:
-            self.sql.remove_emoji(emoji)
+        with self.sql.transaction():
+            for emoji in after - before:
+                self.sql.add_emoji(emoji)
+            for emoji in before - after:
+                self.sql.remove_emoji(emoji)
+

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -14,6 +14,7 @@ from sqlalchemy import ARRAY, Boolean, BigInteger, Column, DateTime
 from sqlalchemy import Integer, String, Table, Unicode, UnicodeText
 from sqlalchemy import MetaData, create_engine
 from sqlalchemy.dialects.postgresql import insert as p_insert
+from threading import RLock
 import unicodedata
 
 from .util import embeds_to_json, get_emoji_id
@@ -35,6 +36,7 @@ class DiscordSqlHandler:
         'db',
         'meta',
         'logger',
+        'lock',
 
         'tb_messages',
         'tb_reactions',
@@ -58,6 +60,7 @@ class DiscordSqlHandler:
         self.db = create_engine(addr)
         self.meta = MetaData(self.db)
         self.logger = logger
+        self.lock = threading.RLock()
 
         # Primary tables
         self.tb_messages = Table('messages', self.meta,

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -23,6 +23,32 @@ __all__ = [
     'DiscordSqlHandler',
 ]
 
+class _Transaction:
+    __slots__ = (
+        'sql',
+        'trans',
+        'logger',
+    )
+
+    def __init__(self, sql):
+        self.sql = sql
+        self.logger = sql.logger
+        self.trans = None
+
+    def __enter__(self):
+        self.logger.debug("Starting transaction...")
+        self.trans = self.sql.conn.begin()
+        return self.sql
+
+    def __exit__(self, type, value, traceback):
+        if (type, value, traceback) == (None, None, None):
+            self.logger.debug("Committing transaction...")
+            self.trans.commit()
+        else:
+            self.logger.error("Exception occurred in 'with' scope!")
+            self.logger.debug("Rolling back transaction...")
+            self.trans.rollback()
+
 class DiscordSqlHandler:
     '''
     An abstract handling class that bridges the gap between
@@ -35,6 +61,7 @@ class DiscordSqlHandler:
     __slots__ = (
         'db',
         'meta',
+        'conn',
         'logger',
         'lock',
 
@@ -59,6 +86,7 @@ class DiscordSqlHandler:
         logger.info(f"Opening database: '{addr}'")
         self.db = create_engine(addr)
         self.meta = MetaData(self.db)
+        self.conn = self.db.connect()
         self.logger = logger
         self.lock = threading.RLock()
 
@@ -137,6 +165,13 @@ class DiscordSqlHandler:
 
         # Create tables
         self.meta.create_all(self.db)
+
+    # Transaction logic
+    def transaction(self):
+        return _Transaction(self)
+
+    def execute(self, *args, **kwargs):
+        self.conn.execute(*args, **kwargs)
 
     # Value builders
     @staticmethod
@@ -218,7 +253,7 @@ class DiscordSqlHandler:
                         index_where=(self.tb_guild_lookup.c.guild_id == guild.id),
                         set_=values,
                 )
-        self.db.execute(ups)
+        self.execute(ups)
         self.guild_cache[guild.id] = values
 
     # Message
@@ -243,7 +278,7 @@ class DiscordSqlHandler:
                     'channel_id': message.channel.id,
                     'guild_id': message.guild.id,
                 })
-        self.db.execute(ins)
+        self.execute(ins)
 
         self.upsert_guild(message.guild)
         self.upsert_channel(message.channel)
@@ -259,9 +294,9 @@ class DiscordSqlHandler:
                     'embeds': embeds_to_json(after.embeds),
                 }) \
                 .where(self.tb_messages.c.message_id == after.id)
-        self.db.execute(upd)
+        self.execute(upd)
 
-    def delete_message(self, message):
+    def remove_message(self, message):
         self.logger.info(f"Deleting message {message.id}")
         upd = self.tb_messages \
                 .update() \
@@ -269,7 +304,7 @@ class DiscordSqlHandler:
                     'is_deleted': True,
                 }) \
                 .where(self.tb_messages.c.message_id == message.id)
-        self.db.execute(upd)
+        self.execute(upd)
 
         self.upsert_guild(message.guild)
         self.upsert_channel(message.channel)
@@ -286,7 +321,7 @@ class DiscordSqlHandler:
                     'channel_id': channel.id,
                     'guild_id': channel.guild.id,
                 })
-        self.db.execute(ins)
+        self.execute(ins)
 
         self.upsert_guild(channel.guild)
         self.upsert_channel(channel)
@@ -304,21 +339,21 @@ class DiscordSqlHandler:
                     'channel_id': reaction.message.channel.id,
                     'guild_id': reaction.message.guild.id,
                 })
-        self.db.execute(ins)
+        self.execute(ins)
 
         self.upsert_guild(reaction.message.guild)
         self.upsert_channel(reaction.message.channel)
         self.upsert_user(user)
         #self.upsert_emoji(reaction.emoji)
 
-    def delete_reaction(self, reaction, user):
-        self.logger.info(f"Deleting reaction for user {user.id} on message {message.id}")
+    def remove_reaction(self, reaction, user):
+        self.logger.info(f"Deleting reaction for user {user.id} on message {reaction.message.id}")
         delet = self.tb_reactions \
                 .delete() \
                 .where(self.tb_reactions.c.message_id == reaction.message.id) \
                 .where(self.tb_reactions.c.emoji_id == get_emoji_id(reaction.emoji)) \
                 .where(self.tb_reactions.c.user_id == user.id)
-        self.db.execute(delet)
+        self.execute(delet)
 
         self.upsert_guild(reaction.message.guild)
         self.upsert_channel(reaction.message.channel)
@@ -330,7 +365,7 @@ class DiscordSqlHandler:
         delet = self.tb_reactions \
                 .delete() \
                 .where(self.tb_reactions.c.message_id == reaction.message.id)
-        self.db.execute(delet)
+        self.execute(delet)
 
     # Pins (TODO)
     def add_pin(self, announce, message):
@@ -347,7 +382,7 @@ class DiscordSqlHandler:
                     'channel_id': message.channel.id,
                     'guild_id': message.guild.id,
                 })
-        self.db.execute(ins)
+        self.execute(ins)
 
     def remove_pin(self, announce, message):
         raise NotImplementedError
@@ -357,7 +392,7 @@ class DiscordSqlHandler:
                 .delete() \
                 .where(self.tb_pins.c.pin_id == announce.id) \
                 .where(self.tb_pins.c.message_id == message.id)
-        self.db.execute(delet)
+        self.execute(delet)
 
     # Roles
     def add_role(self, role):
@@ -370,7 +405,7 @@ class DiscordSqlHandler:
         ins = self.tb_role_lookup \
                 .insert() \
                 .values(values)
-        self.db.execute(ins)
+        self.execute(ins)
         self.role_cache[role.id] = values
 
         self.upsert_guild(role.guild)
@@ -381,7 +416,7 @@ class DiscordSqlHandler:
                 .update() \
                 .values(is_deleted=True) \
                 .where(self.tb_role_lookup.c.role_id == role.id)
-        self.db.execute(upd)
+        self.execute(upd)
         self.role_cache.pop(role.id, None)
 
         self.upsert_guild(role.guild)
@@ -400,7 +435,7 @@ class DiscordSqlHandler:
                         index_where=(self.tb_role_lookup.c.role_id == role.id),
                         set_=values,
                 )
-        self.db.execute(ups)
+        self.execute(ups)
         self.role_cache[role.id] = values
 
         self.upsert_guild(role.guild)
@@ -416,7 +451,7 @@ class DiscordSqlHandler:
         ins = self.tb_channel_lookup \
                 .insert() \
                 .values(values)
-        self.db.execute(ins)
+        self.execute(ins)
         self.channel_cache[channel.id] = values
 
     def _update_channel(self, channel):
@@ -426,7 +461,7 @@ class DiscordSqlHandler:
                 .update() \
                 .where(self.tb_channel_lookup.c.channel_id == channel.id) \
                 .values(values)
-        self.db.execute(upd)
+        self.execute(upd)
         self.channel_cache[channel.id] = values
 
     def update_channel(self, channel):
@@ -441,7 +476,7 @@ class DiscordSqlHandler:
                 .update() \
                 .values(is_deleted=True) \
                 .where(self.tb_channel_lookup.c.channel_id == channel.id)
-        self.db.execute(upd)
+        self.execute(upd)
         self.channel_cache.pop(channel.id, None)
 
     def upsert_channel(self, channel):
@@ -458,7 +493,7 @@ class DiscordSqlHandler:
                         index_where=(self.tb_channel_lookup.c.channel_id == channel.id),
                         set_=values,
                 )
-        self.db.execute(ups)
+        self.execute(ups)
         self.channel_cache[channel.id] = values
 
     # Users
@@ -472,7 +507,7 @@ class DiscordSqlHandler:
         ins = self.tb_user_lookup \
                 .insert() \
                 .values(values)
-        self.db.execute(ins)
+        self.execute(ins)
         self.user_cache[user.id] = values
 
     def _update_user(self, user):
@@ -482,7 +517,7 @@ class DiscordSqlHandler:
                 .update() \
                 .where(self.tb_user_lookup.c.user_id == user.id) \
                 .values(values)
-        self.db.execute(upd)
+        self.execute(upd)
         self.user_cache[user.id] = values
 
     def update_user(self, user):
@@ -497,7 +532,7 @@ class DiscordSqlHandler:
                 .update() \
                 .values(is_deleted=True) \
                 .where(self.tb_user_lookup.c.user_id == user.id)
-        self.db.execute(upd)
+        self.execute(upd)
         self.user_cache.pop(user.id, None)
 
     def upsert_user(self, user):
@@ -513,7 +548,7 @@ class DiscordSqlHandler:
                         index_where=(self.tb_user_lookup.c.user_id == user.id),
                         set_=values,
                 )
-        self.db.execute(ups)
+        self.execute(ups)
         self.user_cache[user.id] = values
 
     # Emojis (TODO)
@@ -530,7 +565,7 @@ class DiscordSqlHandler:
         ins = self.tb_emoji_lookup \
                 .insert() \
                 .values(value)
-        self.db.execute(ins)
+        self.execute(ins)
         self.emoji_cache[id] = values
 
     def remove_emoji(self, emoji):
@@ -542,7 +577,7 @@ class DiscordSqlHandler:
                 .update() \
                 .values(is_deleted=True) \
                 .where(self.tb_emoji_lookup.c.emoji_id == id)
-        self.db.execute(upd)
+        self.execute(upd)
         self.emoji_cache.pop(id, None)
 
     def upsert_emoji(self, emoji):
@@ -561,6 +596,6 @@ class DiscordSqlHandler:
                         index_where=(self.tb_emoji_lookup.c.emoji_id == id),
                         set_=values,
                     )
-        self.db.execute(ups)
+        self.execute(ups)
         self.emoji_cache[id] = values
 

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -36,6 +36,8 @@ class _Transaction:
         self.trans = None
 
     def __enter__(self):
+        self.logger.debug("Acquiring lock for SQL handler...")
+        self.sql.lock.acquire()
         self.logger.debug("Starting transaction...")
         self.trans = self.sql.conn.begin()
         return self.sql
@@ -48,6 +50,7 @@ class _Transaction:
             self.logger.error("Exception occurred in 'with' scope!")
             self.logger.debug("Rolling back transaction...")
             self.trans.rollback()
+        self.sql.lock.release()
 
 class DiscordSqlHandler:
     '''


### PR DESCRIPTION
Fixes #9 

**Requires #7 to be merged first**

This makes it so `with sql.transaction()` also locks the handle (since you should be doing everything within a transaction anyways)
Since this function now serves double-duty, should we rename it? Like `sql.get_context()` or something.