### PR TITLE
Store PostgreSQL data in repo, not globally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 __pycache__
 *.py[cdo]
 
+# Database
+docker/
+postgresql/
+
 # Logging
 *.log
 

--- a/misc/config.json
+++ b/misc/config.json
@@ -6,5 +6,5 @@
     "token": "your_discord_token_here",
     "bot": true,
 
-    "url": "postgresql://username:password@localhost:5432"
+    "url": "postgresql://username:password@localhost:5432/statbot"
 }

--- a/misc/docker-compose.yaml
+++ b/misc/docker-compose.yaml
@@ -6,12 +6,12 @@ PostgreSQL:
   environment:
     - DEBUG=false
 
-    - PG_USERNAME=your_username
-    - PG_PASSWORD=your_password
+    - PG_USERNAME=root
+    - PG_PASSWORD=root
 
-    - DB_USER=
-    - DB_PASS=
-    - DB_NAME=
+    - DB_USER=username
+    - DB_PASS=password
+    - DB_NAME=statbot
     - DB_TEMPLATE=
 
     - DB_EXTENSION=
@@ -21,7 +21,4 @@ PostgreSQL:
     - REPLICATION_PASS=
     - REPLICATION_SSLMODE=
   volumes:
-    - /srv/docker/postgresql:/var/lib/postgresql
-
-# I also needed to do ALTER USER 'name' PASSWORD 'password'.
-
+    - ./docker/postgresql:/var/lib/postgresql

--- a/misc/docker/postgresql/.gitignore
+++ b/misc/docker/postgresql/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/misc/docker/postgresql/.gitignore
+++ b/misc/docker/postgresql/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
From issue #11:

Currently, the docker-compose.yml stores postgres data in `/srv/docker/postgres/` on the host. It would be nice if this data were stored inside the repository instead, so that it cannot affect other applications or copies of the repository.

Fixes #11 