### PR TITLE
Fix "first_message_id" issue by explicitly loading it

### DIFF
--- a/statbot/crawler.py
+++ b/statbot/crawler.py
@@ -59,8 +59,8 @@ class DiscordHistoryCrawler:
                             mhist = self.sql.lookup_message_hist(trans, channel)
 
                             if mhist is None:
-                                mhist = self.sql.insert_message_hist(trans, channel)
-                                mhist.first = await self._chan_first(channel)
+                                first = await self._chan_first(channel)
+                                mhist = self.sql.insert_message_hist(trans, channel, first)
 
                             self.progress[channel.id] = mhist
 
@@ -164,7 +164,7 @@ class DiscordHistoryCrawler:
         self.logger.info(f"Adding #{channel.name} to tracked channels")
 
         with self.sql.transaction() as trans:
-            mhist = self.sql.insert_message_hist(trans, channel)
+            mhist = self.sql.insert_message_hist(trans, channel, None)
         self.progress[channel.id] = mhist
 
     async def _channel_delete_hook(self, channel):
@@ -180,9 +180,9 @@ class DiscordHistoryCrawler:
                 return
 
             self.logger.info(f"Updating #{after.name} - adding to list")
-
             with self.sql.transaction() as trans:
-                mhist = self.sql.insert_message_hist(trans, after)
+                first = await self._chan_first(after)
+                mhist = self.sql.insert_message_hist(trans, after, first)
             self.progress[after.id] = mhist
         else:
             self.logger.info(f"Updating #{after.name} - removing from list")

--- a/statbot/emoji.py
+++ b/statbot/emoji.py
@@ -63,11 +63,6 @@ class EmojiData:
         return (self.id, self.unicode)
 
     def values(self):
-        if self.roles is not None:
-            roles = list(map(lambda r: r.id, self.roles))
-        else:
-            roles = []
-
         return {
             'emoji_id': self.id,
             'emoji_unicode': self.unicode,
@@ -76,7 +71,7 @@ class EmojiData:
             'is_deleted': False,
             'name': self.name,
             'category': self.category,
-            'roles': roles,
+            'roles': list(map(lambda r: r.id, self.roles or [])),
             'guild_id': getattr(self.guild, 'id', None),
         }
 

--- a/statbot/emoji.py
+++ b/statbot/emoji.py
@@ -63,6 +63,11 @@ class EmojiData:
         return (self.id, self.unicode)
 
     def values(self):
+        if self.roles is not None:
+            roles = list(map(lambda r: r.id, self.roles))
+        else:
+            roles = []
+
         return {
             'emoji_id': self.id,
             'emoji_unicode': self.unicode,
@@ -71,7 +76,7 @@ class EmojiData:
             'is_deleted': False,
             'name': self.name,
             'category': self.category,
-            'roles': [role.id for role in self.roles],
+            'roles': roles,
             'guild_id': getattr(self.guild, 'id', None),
         }
 

--- a/statbot/message_history.py
+++ b/statbot/message_history.py
@@ -26,6 +26,8 @@ class MessageHistory(MultiRange):
         self.first = first
 
     def find_first_hole(self, start):
+        ''' Finds the first hole in the MultiRange starting from the given point '''
+
         current = start
         for range in reversed(self.ranges):
             if start > range.max():
@@ -38,6 +40,8 @@ class MessageHistory(MultiRange):
             return None
 
     def to_ranges(self):
+        ''' Converts this object into two lists for insertion into the database '''
+
         starts = []
         ends = []
 

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -1023,9 +1023,9 @@ class DiscordSqlHandler:
         else:
             return None
 
-    def insert_message_hist(self, trans, channel):
+    def insert_message_hist(self, trans, channel, first):
         self.logger.info(f"Inserting new message history for #{channel.name}")
-        mhist = MessageHistory()
+        mhist = MessageHistory(first=first)
         values = message_hist_values(channel, mhist)
 
         ins = self.tb_crawl_ranges \

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -392,8 +392,7 @@ class DiscordSqlHandler:
                 Column('is_deleted', Boolean),
                 Column('position', Integer))
         self.tb_crawl_ranges = Table('crawl_ranges', meta,
-                Column('channel_id', BigInteger,
-                    ForeignKey('channels.channel_id'), primary_key=True),
+                Column('channel_id', BigInteger, primary_key=True),
                 Column('first_message_id', BigInteger,
                     ForeignKey('messages.message_id'), nullable=True),
                 Column('start_ranges', ARRAY(BigInteger)),

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -393,8 +393,7 @@ class DiscordSqlHandler:
                 Column('position', Integer))
         self.tb_crawl_ranges = Table('crawl_ranges', meta,
                 Column('channel_id', BigInteger, primary_key=True),
-                Column('first_message_id', BigInteger,
-                    ForeignKey('messages.message_id'), nullable=True),
+                Column('first_message_id', BigInteger, nullable=True),
                 Column('start_ranges', ARRAY(BigInteger)),
                 Column('end_ranges', ARRAY(BigInteger)))
 


### PR DESCRIPTION
Fixes #30 

Previously, we would determine the end of a channel by continually calling `history()` until a result is returned that is smaller than the number of requested items. However this ended up causing problems when the crawler would mistakenly think crawling was over before it actually was.

This PR fixes that by first retrieving the earliest message in the channel, inserting it immediately into the table, and then using that as a reference to determine if crawling is finished.