### PR TITLE
Add caching to events

### DIFF
--- a/misc/config.yaml
+++ b/misc/config.yaml
@@ -4,6 +4,9 @@ guild-ids:
   - 129409120491092041
   - 1290192091029091120
 
+cache:
+  size: 16
+
 logger:
   full-messages: false
   ignored-events: false

--- a/misc/config.yaml
+++ b/misc/config.yaml
@@ -1,11 +1,11 @@
 ---
 
 guild-ids:
-  - 129409120491092041
-  - 1290192091029091120
+  - 193593039650100397
 
 cache:
-  size: 16
+  event-size: 16
+  lookup-size: 384
 
 logger:
   full-messages: false

--- a/statbot/__main__.py
+++ b/statbot/__main__.py
@@ -98,7 +98,7 @@ if __name__ == '__main__':
         exit(1)
 
     # Create SQL handler
-    sql = DiscordSqlHandler(config['bot']['db-url'], config['cache']['size'], sql_logger)
+    sql = DiscordSqlHandler(config['bot']['db-url'], config['cache'], sql_logger)
 
     # Create client
     main_logger.info("Setting up bot")

--- a/statbot/__main__.py
+++ b/statbot/__main__.py
@@ -98,7 +98,7 @@ if __name__ == '__main__':
         exit(1)
 
     # Create SQL handler
-    sql = DiscordSqlHandler(config['bot']['db-url'], sql_logger)
+    sql = DiscordSqlHandler(config['bot']['db-url'], config['cache']['size'], sql_logger)
 
     # Create client
     main_logger.info("Setting up bot")

--- a/statbot/cache.py
+++ b/statbot/cache.py
@@ -1,0 +1,57 @@
+#
+# cache.py
+#
+# statbot - Store Discord records for later analysis
+# Copyright (c) 2017 Ammon Smith
+#
+# statbot is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+from collections import MutableMapping, OrderedDict
+
+__all__ = [
+    'LruCache',
+]
+
+class LruCache(MutableMapping):
+    __slots__ = (
+        'store',
+        'max_size',
+    )
+
+    def __init__(self, max_size=None):
+        self.store = OrderedDict()
+        self.max_size = max_size
+
+    def __getitem__(self, key):
+        obj = self.store.pop(key)
+        self.store[key] = obj
+        return obj
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def __setitem__(self, key, value):
+        self.store.pop(key, None)
+        self.store[key] = value
+
+        while len(self) > self.max_size:
+            self.store.popitem(last=False)
+
+    def __delitem__(self, key):
+        del self.store[key]
+
+    def __contains__(self, key):
+        return key in self.store
+
+    def __iter__(self):
+        return iter(self.store)
+
+    def __len__(self):
+        return len(self.store)

--- a/statbot/config.py
+++ b/statbot/config.py
@@ -56,11 +56,17 @@ def check(cfg, logger=null_logger):
         if not is_int_list(cfg['guild-ids']):
             logger.error("Configuration field 'guilds' is not an int list")
             return False
-        if not isinstance(cfg['cache']['size'], int):
-            logger.error("Configuration field 'cache.size' is not an int")
+        if not isinstance(cfg['cache']['event-size'], int):
+            logger.error("Configuration field 'cache.event-size' is not an int")
             return False
-        if cfg['cache']['size'] <= 0:
-            logger.error("Configuration field 'cache.size' is zero or negative")
+        if cfg['cache']['event-size'] <= 0:
+            logger.error("Configuration field 'cache.event-size' is zero or negative")
+            return False
+        if not isinstance(cfg['cache']['lookup-size'], int):
+            logger.error("Configuration field 'cache.lookup-size' is not an int")
+            return False
+        if cfg['cache']['lookup-size'] <= 0:
+            logger.error("Configuration field 'cache.lookup-size' is zero or negative")
             return False
         if not isinstance(cfg['logger']['full-messages'], bool):
             logger.error("Configuration field 'logger.full-messages' is not a bool")

--- a/statbot/config.py
+++ b/statbot/config.py
@@ -56,6 +56,12 @@ def check(cfg, logger=null_logger):
         if not is_int_list(cfg['guild-ids']):
             logger.error("Configuration field 'guilds' is not an int list")
             return False
+        if not isinstance(cfg['cache']['size'], int):
+            logger.error("Configuration field 'cache.size' is not an int")
+            return False
+        if cfg['cache']['size'] <= 0:
+            logger.error("Configuration field 'cache.size' is zero or negative")
+            return False
         if not isinstance(cfg['logger']['full-messages'], bool):
             logger.error("Configuration field 'logger.full-messages' is not a bool")
             return False

--- a/statbot/sql.py
+++ b/statbot/sql.py
@@ -251,7 +251,7 @@ class DiscordSqlHandler:
         'role_cache',
     )
 
-    def __init__(self, addr, cache_max_size, logger=null_logger):
+    def __init__(self, addr, cache_size, logger=null_logger):
         logger.info(f"Opening database: '{addr}'")
         self.db = create_engine(addr)
         meta = MetaData(self.db)
@@ -415,15 +415,15 @@ class DiscordSqlHandler:
                 Column('last_audit_entry_id', BigInteger))
 
         # Caches
-        self.message_cache = LruCache(cache_max_size)
-        self.typing_cache = LruCache(cache_max_size)
-        self.guild_cache = LruCache(cache_max_size)
-        self.channel_cache = LruCache(cache_max_size)
-        self.voice_channel_cache = LruCache(cache_max_size)
-        self.channel_category_cache = LruCache(cache_max_size)
-        self.user_cache = LruCache(cache_max_size)
-        self.emoji_cache = LruCache(cache_max_size)
-        self.role_cache = LruCache(cache_max_size)
+        self.message_cache = LruCache(cache_size['event-size'])
+        self.typing_cache = LruCache(cache_size['event-size'])
+        self.guild_cache = LruCache(cache_size['lookup-size'])
+        self.channel_cache = LruCache(cache_size['lookup-size'])
+        self.voice_channel_cache = LruCache(cache_size['lookup-size'])
+        self.channel_category_cache = LruCache(cache_size['lookup-size'])
+        self.user_cache = LruCache(cache_size['lookup-size'])
+        self.emoji_cache = LruCache(cache_size['lookup-size'])
+        self.role_cache = LruCache(cache_size['lookup-size'])
 
         # Create tables
         meta.create_all(self.db)


### PR DESCRIPTION
This will prevent multiple events being received from causing excessive number of SQL insertion failures. This also replaces the "cache" fields with actual LRU caches, instead of dictionaries which are never evicted.