### PR TITLE
Improve audit log entry collection

### DIFF
--- a/statbot/audit_log.py
+++ b/statbot/audit_log.py
@@ -10,10 +10,7 @@
 # WITHOUT ANY WARRANTY. See the LICENSE file for more details.
 #
 
-from enum import Enum
-
 __all__ = [
-    'AuditLogChangeState',
     'AuditLogData',
 ]
 
@@ -61,10 +58,6 @@ VALUE_ATTRS = (
     'raw_deny_permissions',
 )
 
-class AuditLogChangeState(Enum):
-    BEFORE = 0
-    AFTER = 1
-
 class AuditLogData:
     __slots__ = (
         'entry',
@@ -83,6 +76,8 @@ class AuditLogData:
             'user_id': self.entry.user.id,
             'reason': self.entry.reason,
             'category': self.entry.category,
+            'before': self.diff_values(self.entry.before),
+            'after': self.diff_values(self.entry.after),
         }
 
     @staticmethod
@@ -106,15 +101,9 @@ class AuditLogData:
             'deny': deny_perms,
         }
 
-    def diff_values(self, state):
+    def diff_values(self, diff):
         if self.entry.category is None:
             return None
-
-        alcs = AuditLogChangeState(state)
-        if alcs == AuditLogChangeState.BEFORE:
-            diff = self.entry.before
-        elif alcs == AuditLogChangeState.AFTER:
-            diff = self.entry.after
 
         attributes = {}
 
@@ -145,9 +134,4 @@ class AuditLogData:
         if obj is not None:
             attributes['overwrites'] = obj
 
-        return {
-            'audit_entry_id': self.entry.id,
-            'guild_id': self.guild.id,
-            'state': state,
-            'attributes': attributes,
-        }
+        return attributes

--- a/statbot/audit_log.py
+++ b/statbot/audit_log.py
@@ -108,30 +108,42 @@ class AuditLogData:
         attributes = {}
 
         for attr in NAME_ATTRS:
-            obj = getattr(diff, attr, None)
-            if obj is not None:
+            try:
+                obj = getattr(diff, attr)
                 attributes[attr] = obj
+            except AttributeError:
+                pass
 
         for attr in ID_ATTRS:
-            obj = getattr(diff, attr, None)
-            if obj is not None:
+            try:
+                obj = getattr(diff, attr)
                 attributes[attr] = obj.id
+            except AttributeError:
+                pass
 
         for attr in VALUE_ATTRS:
-            obj = getattr(diff, attr, None)
-            if obj is not None:
+            try:
+                obj = getattr(diff, attr)
                 attributes[attr] = obj.value
+            except AttributeError:
+                pass
 
-        obj = getattr(diff, 'mfa_level', None)
-        if obj is not None:
+        try:
+            obj = getattr(diff, 'mfa_level')
             attributes['mfa'] = bool(obj)
+        except AttributeError:
+            pass
 
-        obj = getattr(diff, 'roles', None)
-        if obj is not None:
+        try:
+            obj = getattr(diff, 'roles')
             attributes['roles'] = list(map(lambda x: x.id, obj))
+        except AttributeError:
+            pass
 
-        obj = self._get_overwrites(getattr(diff, 'overwrites', None))
-        if obj is not None:
+        try:
+            obj = self._get_overwrites(getattr(diff, 'overwrites'))
             attributes['overwrites'] = obj
+        except AttributeError:
+            pass
 
         return attributes

--- a/statbot/crawler.py
+++ b/statbot/crawler.py
@@ -200,6 +200,10 @@ class HistoryCrawler(AbstractCrawler):
         with self.sql.transaction() as trans:
             self.sql.insert_channel_crawl(trans, channel, 0)
 
+    def _update_progress(self, channel):
+        with self.sql.transaction() as trans:
+            self.sql.update_channel_crawl(trans, channel, self.progress[channel])
+
     def _delete_progress(self, channel):
         self.progress.pop(channel, None)
 
@@ -226,7 +230,7 @@ class HistoryCrawler(AbstractCrawler):
                 return
 
             self.logger.info(f"Updating #{after.name} - adding to list")
-            self._create_progress(after)
+            self._update_progress(after)
         else:
             self.logger.info(f"Updating #{after.name} - removing from list")
             self._delete_progress(after)

--- a/statbot/crawler.py
+++ b/statbot/crawler.py
@@ -252,12 +252,12 @@ class AuditLogCrawler(AbstractCrawler):
         self.logger.info(f"Starting from ID {last_id} ({last})")
 
         entries = await guild.audit_logs(after=last, limit=limit).flatten()
-        if not entries or self.get_last_id(entries) <= last_id:
-            self.logger.info("No audit log entries found in this range")
-            return None
-        else:
+        if entries and self.get_last_id(entries) != last_id:
             self.logger.info(f"Queued {len(entries)} audit log entries for ingestion")
             return entries
+        else:
+            self.logger.info("No audit log entries found in this range")
+            return None
 
     async def write(self, trans, guild, entries):
         # pylint: disable=arguments-differ

--- a/statbot/crawler.py
+++ b/statbot/crawler.py
@@ -255,6 +255,10 @@ class AuditLogCrawler(AbstractCrawler):
         self.logger.info(f"Reading through {guild.name}'s audit logs")
         self.logger.info(f"Starting from ID {last_id} ({last})")
 
+        # Weirdly, .audit_logs() behaves differently from other history functions.
+        # It will give us entries not in our specified range of "after=last".
+        # As a simple remedy, we keep on slamming it with requests until it gives
+        # us the same list twice in a row, and then we know we're done.
         entries = await guild.audit_logs(after=last, limit=limit).flatten()
         if entries and self.get_last_id(entries) != last_id:
             self.logger.info(f"Queued {len(entries)} audit log entries for ingestion")


### PR DESCRIPTION
Fixes #46 

An invalid check was making the crawler think the source was prematurely exhausted. Compare the new code with how the history crawler checks IDs.